### PR TITLE
improve: update README and fix WezTerm path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,38 @@ $ sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply nananaman
 
 ## Install Tools
 
-Vim, fish, wezterm, etc.
-
 ```
 $ chezmoi cd && bash ./scripts/init.sh
+```
+
+This will install and configure:
+- Neovim
+- Fish shell
+- Nushell
+- Wezterm
+- Zsh
+- Additional tools and fonts
+
+## Configuration Structure
+
+```
+dot_config/
+  ├── chezmoi/        # chezmoi configuration
+  ├── cspell/         # spell checking configuration
+  ├── fish/           # fish shell configuration
+  ├── ghostty/        # ghostty terminal configuration
+  ├── lazygit/        # lazygit configuration
+  ├── nushell/        # nushell configuration
+  ├── nvim/           # neovim configuration
+  ├── sheldon/        # shell plugin manager
+  ├── sql-formatter/  # SQL formatter configuration
+  └── wezterm/        # wezterm terminal configuration
+```
+
+## Managing Dotfiles
+
+```
+$ chezmoi diff    # See pending changes
+$ chezmoi apply   # Apply changes
+$ chezmoi cd      # Navigate to the repository
 ```


### PR DESCRIPTION
## Summary
- Add detailed README documentation with configuration structure
- Fix WezTerm path handling by removing file:// prefix from paths

## Test plan
- Verify README displays correctly with added documentation
- Confirm WezTerm tab titles display paths correctly without file:// prefix

🤖 Generated with [Claude Code](https://claude.ai/code)