### PR TITLE
feat: add WSL home-manager config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,13 @@
       ...
     }:
     let
-      username = "juntawatanabe";
-      homedir = "/Users/${username}";
-      dotfilesDir = "${homedir}/ghq/github.com/chouge/dotfiles";
+      darwinUsername = "juntawatanabe";
+      darwinHomedir = "/Users/${darwinUsername}";
+      darwinDotfilesDir = "${darwinHomedir}/ghq/github.com/chouge/dotfiles";
+
+      wslUsername = "chouge";
+      wslHomedir = "/home/${wslUsername}";
+      wslDotfilesDir = "${wslHomedir}/ghq/github.com/nananaman/dotfiles";
 
       mkPkgs =
         system:
@@ -41,23 +45,35 @@
         };
     in
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "aarch64-darwin" ];
+      systems = [
+        "aarch64-darwin"
+        "x86_64-linux"
+      ];
 
       perSystem =
         { system, ... }:
         let
           pkgs = mkPkgs system;
-          hostname = username;
+          isDarwin = system == "aarch64-darwin";
+          configName = if isDarwin then darwinUsername else wslUsername;
+          buildTarget =
+            if isDarwin then
+              "darwinConfigurations.${configName}.system"
+            else
+              "homeConfigurations.${configName}.activationPackage";
+          homeManager = home-manager.packages.${system}.home-manager;
         in
         {
+          formatter = pkgs.nixfmt;
+
           apps = {
             build = {
               type = "app";
               program = toString (
-                pkgs.writeShellScript "darwin-build" ''
+                pkgs.writeShellScript "nix-build-config" ''
                   set -e
-                  echo "Building darwin configuration..."
-                  nix build .#darwinConfigurations.${hostname}.system
+                  echo "Building ${buildTarget}..."
+                  nix build .#${buildTarget}
                   echo "Build successful! Run 'nix run .#switch' to apply."
                 ''
               );
@@ -66,12 +82,22 @@
             switch = {
               type = "app";
               program = toString (
-                pkgs.writeShellScript "darwin-switch" ''
-                  set -eo pipefail
-                  echo "Building and switching to darwin configuration..."
-                  sudo nix run nix-darwin -- switch --flake .#${hostname}
-                  echo "Done!"
-                ''
+                pkgs.writeShellScript "nix-switch-config" (
+                  if isDarwin then
+                    ''
+                      set -eo pipefail
+                      echo "Building and switching to darwin configuration..."
+                      sudo nix run nix-darwin -- switch --flake .#${configName}
+                      echo "Done!"
+                    ''
+                  else
+                    ''
+                      set -eo pipefail
+                      echo "Building and switching to home-manager configuration..."
+                      ${homeManager}/bin/home-manager switch --flake .#${configName}
+                      echo "Done!"
+                    ''
+                )
               );
             };
 
@@ -95,14 +121,15 @@
           darwinPkgs = mkPkgs darwinSystem;
         in
         {
-          darwinConfigurations.${username} = nix-darwin.lib.darwinSystem {
+          darwinConfigurations.${darwinUsername} = nix-darwin.lib.darwinSystem {
             system = darwinSystem;
 
             modules = [
               (import ./nix/modules/darwin/system.nix {
                 pkgs = darwinPkgs;
                 inherit (darwinPkgs) lib;
-                inherit username homedir;
+                username = darwinUsername;
+                homedir = darwinHomedir;
               })
 
               home-manager.darwinModules.home-manager
@@ -111,7 +138,7 @@
                   useGlobalPkgs = true;
                   useUserPackages = true;
                   backupFileExtension = "hm-backup";
-                  users.${username} =
+                  users.${darwinUsername} =
                     {
                       pkgs,
                       config,
@@ -120,6 +147,7 @@
                     }:
                     let
                       helpers = import ./nix/modules/lib/helpers { inherit lib; };
+                      dotfilesDir = darwinDotfilesDir;
                     in
                     {
                       imports = [
@@ -136,6 +164,41 @@
                     };
                 };
               }
+            ];
+          };
+
+          homeConfigurations.${wslUsername} = home-manager.lib.homeManagerConfiguration {
+            pkgs = mkPkgs "x86_64-linux";
+            modules = [
+              (
+                {
+                  pkgs,
+                  config,
+                  lib,
+                  ...
+                }:
+                let
+                  helpers = import ./nix/modules/lib/helpers { inherit lib; };
+                  dotfilesDir = wslDotfilesDir;
+                in
+                {
+                  imports = [
+                    (import ./nix/modules/home {
+                      inherit
+                        pkgs
+                        config
+                        lib
+                        helpers
+                        dotfilesDir
+                        ;
+                    })
+                  ];
+
+                  home.username = wslUsername;
+                  home.homeDirectory = wslHomedir;
+                  targets.genericLinux.enable = true;
+                }
+              )
             ];
           };
         };

--- a/ghostty/config
+++ b/ghostty/config
@@ -5,20 +5,19 @@ keybind = "global:ctrl+cmd+`=toggle_quick_terminal"
 unfocused-split-opacity = 0.8
 unfocused-split-fill = #000000
 
-# Tab
-keybind = shift+ctrl+w=new_tab
-keybind = shift+ctrl+h=previous_tab
-keybind = shift+ctrl+l=next_tab
-
-# Pane
-keybind = ctrl+g>|+shift=new_split:right
-keybind = ctrl+g>-=new_split:down
-keybind = shift+arrow_left=goto_split:left
-keybind = shift+arrow_right=goto_split:right
-keybind = shift+arrow_up=goto_split:up
-keybind = shift+arrow_down=goto_split:down
-keybind = shift+ctrl+x=close_surface
-keybind = shift+ctrl+z=toggle_split_zoom
+# Tab / Pane
+# Zellij に同じキーを渡すため、Ghostty 側では捕捉しない。
+# keybind = shift+ctrl+w=new_tab
+# keybind = shift+ctrl+h=previous_tab
+# keybind = shift+ctrl+l=next_tab
+# keybind = ctrl+g>|+shift=new_split:right
+# keybind = ctrl+g>-=new_split:down
+# keybind = shift+arrow_left=goto_split:left
+# keybind = shift+arrow_right=goto_split:right
+# keybind = shift+arrow_up=goto_split:up
+# keybind = shift+arrow_down=goto_split:down
+# keybind = shift+ctrl+x=close_surface
+# keybind = shift+ctrl+z=toggle_split_zoom
 
 # Other
 keybind = shift+ctrl+r=reload_config

--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -1,4 +1,4 @@
 git:
-  paging:
-    colorArg: always
-    pager: delta --dark --paging=never
+  pagers:
+    - colorArg: always
+      pager: delta --dark --paging=never

--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -22,6 +22,7 @@
 
     (import ./dotfiles.nix {
       inherit
+        pkgs
         lib
         config
         dotfilesDir

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   lib,
   config,
   dotfilesDir,
@@ -19,16 +20,38 @@ in
     link_force "${dotfilesDir}/zsh/sheldon" "${configHome}/sheldon"
 
     link_force "${dotfilesDir}/ghostty" "${configHome}/ghostty"
-    $DRY_RUN_CMD mkdir -p "${homeDirectory}/Library/Application Support/com.mitchellh.ghostty"
-    link_force "${dotfilesDir}/ghostty/config" "${homeDirectory}/Library/Application Support/com.mitchellh.ghostty/config"
+    ${lib.optionalString pkgs.stdenv.isDarwin ''
+      $DRY_RUN_CMD mkdir -p "${homeDirectory}/Library/Application Support/com.mitchellh.ghostty"
+      link_force "${dotfilesDir}/ghostty/config" "${homeDirectory}/Library/Application Support/com.mitchellh.ghostty/config"
+    ''}
 
-    link_force "${dotfilesDir}/aerospace/aerospace.toml" "${homeDirectory}/.aerospace.toml"
+    link_force "${dotfilesDir}/zellij" "${configHome}/zellij"
+
+    ${lib.optionalString pkgs.stdenv.isDarwin ''
+      link_force "${dotfilesDir}/aerospace/aerospace.toml" "${homeDirectory}/.aerospace.toml"
+    ''}
     link_force "${dotfilesDir}/lazygit" "${configHome}/lazygit"
     link_force "${dotfilesDir}/cspell" "${configHome}/cspell"
     link_force "${dotfilesDir}/sql-formatter" "${configHome}/sql-formatter"
     link_force "${dotfilesDir}/stylua.toml" "${configHome}/stylua.toml"
 
     link_force "${dotfilesDir}/.apm" "${homeDirectory}/.apm"
+
+    ${lib.optionalString pkgs.stdenv.isLinux ''
+      cmd_exe="/mnt/c/Windows/System32/cmd.exe"
+      wslpath_exe="/usr/bin/wslpath"
+      if [ -x "$cmd_exe" ] && [ -x "$wslpath_exe" ]; then
+        win_profile="$(${pkgs.coreutils}/bin/timeout 2s "$cmd_exe" /c 'echo %USERPROFILE%' 2>/dev/null | ${pkgs.coreutils}/bin/tr -d '\r' || true)"
+        if [ -n "$win_profile" ] && win_profile="$($wslpath_exe "$win_profile" 2>/dev/null)"; then
+          for wt_package in Microsoft.WindowsTerminal_8wekyb3d8bbwe Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe; do
+            wt_dir="$win_profile/AppData/Local/Packages/$wt_package/LocalState"
+            if [ -d "$wt_dir" ]; then
+              $DRY_RUN_CMD cp "${dotfilesDir}/windows-terminal/settings.json" "$wt_dir/settings.json"
+            fi
+          done
+        fi
+      fi
+    ''}
 
     $DRY_RUN_CMD mkdir -p "${configHome}/git"
     link_force "${dotfilesDir}/git/ignore" "${configHome}/git/ignore"

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -107,8 +107,10 @@ in
     # Development
     go
     deno
+    nixfmt
     neovim
     apm-cli
+    zellij
 
     # Cloud
     google-cloud-sdk

--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -1,0 +1,213 @@
+{
+    "$help": "https://aka.ms/terminal-documentation",
+    "$schema": "https://aka.ms/terminal-profiles-schema",
+    "actions": [
+        {
+            "command": {
+                "action": "copy",
+                "singleLine": false
+            },
+            "id": "User.copy.644BA8F2"
+        },
+        {
+            "command": "paste",
+            "id": "User.paste"
+        },
+        {
+            "command": "find",
+            "id": "User.find"
+        },
+        {
+            "command": {
+                "action": "splitPane",
+                "split": "auto",
+                "splitMode": "duplicate"
+            },
+            "id": "User.splitPane.A6751878"
+        },
+        {
+            "command": {
+                "action": "sendInput",
+                "input": "\u001bw"
+            },
+            "keys": "ctrl+shift+w"
+        }
+    ],
+    "copyFormatting": "none",
+    "copyOnSelect": false,
+    "defaultProfile": "{c7e4d7fa-7a66-57be-aec6-e20808e6d177}",
+    "keybindings": [
+        {
+            "id": "User.copy.644BA8F2",
+            "keys": "ctrl+c"
+        },
+        {
+            "id": "User.find",
+            "keys": "ctrl+shift+f"
+        },
+        {
+            "id": "User.paste",
+            "keys": "ctrl+v"
+        },
+        {
+            "id": "User.splitPane.A6751878",
+            "keys": "alt+shift+d"
+        }
+    ],
+    "newTabMenu": [
+        {
+            "type": "remainingProfiles"
+        }
+    ],
+    "profiles": {
+        "defaults": {},
+        "list": [
+            {
+                "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+                "hidden": false,
+                "name": "Windows PowerShell"
+            },
+            {
+                "commandline": "%SystemRoot%\\System32\\cmd.exe",
+                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+                "hidden": false,
+                "name": "コマンド プロンプト"
+            },
+            {
+                "guid": "{17bf3de4-5353-5709-bcf9-835bd952a95e}",
+                "hidden": true,
+                "name": "Ubuntu-22.04",
+                "source": "Windows.Terminal.Wsl"
+            },
+            {
+                "guid": "{b453ae62-4e3d-5e58-b989-0a998ec441b8}",
+                "hidden": false,
+                "name": "Azure Cloud Shell",
+                "source": "Windows.Terminal.Azure"
+            },
+            {
+                "guid": "{51855cb2-8cce-5362-8f54-464b92b32386}",
+                "hidden": false,
+                "name": "Ubuntu",
+                "source": "CanonicalGroupLimited.Ubuntu_79rhkp1fndgsc"
+            },
+            {
+                "guid": "{d8e96812-b789-5068-a5ae-10b2fb53e95f}",
+                "hidden": false,
+                "name": "Ubuntu 24.04.1 LTS",
+                "source": "CanonicalGroupLimited.Ubuntu24.04LTS_79rhkp1fndgsc"
+            },
+            {
+                "guid": "{d159dfce-fcb0-57ba-8f85-3d50bb985e64}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{cb88a99f-7ae3-5a4f-9202-492ceaeb1d5a}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{0a29cfce-a418-5a96-b98c-e9bf2439ac33}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{7fd27129-b88a-5792-8147-54046d0aab03}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{12d9a14f-b55b-5959-b305-61301f0cae0f}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{bf5d9baa-f517-53a7-8985-3674d75e6760}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{171f1434-f5f9-581e-bff6-13f002fd4baf}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{6503db85-c211-5021-a7bd-90944b0644db}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{0b09414b-f8a8-5238-9ab1-63fd5592e6f6}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{343c4f33-9d1a-51ed-ac7e-95a290787a80}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{ba70ff28-57c5-50ef-ae13-05471541068c}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{42ef70a9-d5fd-50e1-9c42-f0db7ef6c471}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{eb1b3c79-67d2-5cb9-aeeb-746a786b10d2}",
+                "hidden": false,
+                "name": "docker-desktop",
+                "source": "Microsoft.WSL"
+            },
+            {
+                "guid": "{c7e4d7fa-7a66-57be-aec6-e20808e6d177}",
+                "hidden": false,
+                "name": "Ubuntu",
+                "source": "Microsoft.WSL"
+            }
+        ]
+    },
+    "schemes": [
+        {
+            "background": "#300A24",
+            "black": "#171421",
+            "blue": "#0037DA",
+            "brightBlack": "#767676",
+            "brightBlue": "#08458F",
+            "brightCyan": "#2C9FB3",
+            "brightGreen": "#26A269",
+            "brightPurple": "#A347BA",
+            "brightRed": "#C01C28",
+            "brightWhite": "#F2F2F2",
+            "brightYellow": "#A2734C",
+            "cursorColor": "#FFFFFF",
+            "cyan": "#3A96DD",
+            "foreground": "#FFFFFF",
+            "green": "#26A269",
+            "name": "Ubuntu-22.04-ColorScheme",
+            "purple": "#881798",
+            "red": "#C21A23",
+            "selectionBackground": "#FFFFFF",
+            "white": "#CCCCCC",
+            "yellow": "#A2734C"
+        }
+    ],
+    "themes": []
+}

--- a/zellij/config.kdl
+++ b/zellij/config.kdl
@@ -1,0 +1,327 @@
+// Plugin aliases - can be used to change the implementation of Zellij
+// changing these requires a restart to take effect
+plugins {
+    about location="zellij:about"
+    compact-bar location="zellij:compact-bar"
+    configuration location="zellij:configuration"
+    filepicker location="zellij:strider" {
+        cwd "/"
+    }
+    plugin-manager location="zellij:plugin-manager"
+    session-manager location="zellij:session-manager"
+    status-bar location="zellij:status-bar"
+    strider location="zellij:strider"
+    tab-bar location="zellij:tab-bar"
+    welcome-screen location="zellij:session-manager" {
+        welcome_screen true
+    }
+}
+
+// Plugins to load in the background when a new session starts
+// eg. "file:/path/to/my-plugin.wasm"
+// eg. "https://example.com/my-plugin.wasm"
+load_plugins {
+    zellij:link
+}
+web_client {
+    font "monospace"
+}
+ 
+// Use a simplified UI without special fonts (arrow glyphs)
+// Options:
+//   - true
+//   - false (Default)
+// 
+// simplified_ui true
+ 
+// Enable OSC8 hyperlink output
+// Options:
+//   - true (Default)
+//   - false
+// 
+// osc8_hyperlinks true
+ 
+// Choose the theme that is specified in the themes section.
+// Default: default
+// 
+// theme "dracula"
+ 
+// Theme to use when the host terminal reports a dark color palette.
+// Requires `theme_light` to also be set; otherwise `theme` is used.
+// 
+// theme_dark "dracula"
+ 
+// Theme to use when the host terminal reports a light color palette.
+// Requires `theme_dark` to also be set; otherwise `theme` is used.
+// 
+// theme_light "solarized-light"
+ 
+// Choose the base input mode of zellij.
+// Default: normal
+// 
+// default_mode "locked"
+ 
+// Choose the path to the default shell that zellij will use for opening new panes
+// Default: $SHELL
+// 
+// default_shell "fish"
+ 
+// Choose the path to override cwd that zellij will use for opening new panes
+// 
+// default_cwd "/tmp"
+ 
+// The name of the default layout to load on startup
+// Default: "default"
+// 
+// default_layout "compact"
+ 
+// The folder in which Zellij will look for layouts
+// (Requires restart)
+// 
+// layout_dir "/tmp"
+ 
+// The folder in which Zellij will look for themes
+// (Requires restart)
+// 
+// theme_dir "/tmp"
+ 
+// Toggle enabling the mouse mode.
+// On certain configurations, or terminals this could
+// potentially interfere with copying text.
+// Options:
+//   - true (default)
+//   - false
+// 
+// mouse_mode false
+ 
+// Toggle having pane frames around the panes
+// Options:
+//   - true (default, enabled)
+//   - false
+// 
+// pane_frames false
+ 
+// When attaching to an existing session with other users,
+// should the session be mirrored (true)
+// or should each user have their own cursor (false)
+// (Requires restart)
+// Default: false
+// 
+// mirror_session true
+ 
+// Choose what to do when zellij receives SIGTERM, SIGINT, SIGQUIT or SIGHUP
+// eg. when terminal window with an active zellij session is closed
+// (Requires restart)
+// Options:
+//   - detach (Default)
+//   - quit
+// 
+// on_force_close "quit"
+ 
+// Configure the scroll back buffer size
+// This is the number of lines zellij stores for each pane in the scroll back
+// buffer. Excess number of lines are discarded in a FIFO fashion.
+// (Requires restart)
+// Valid values: positive integers
+// Default value: 10000
+// 
+// scroll_buffer_size 10000
+ 
+// Provide a command to execute when copying text. The text will be piped to
+// the stdin of the program to perform the copy. This can be used with
+// terminal emulators which do not support the OSC 52 ANSI control sequence
+// that will be used by default if this option is not set.
+// Examples:
+//
+// copy_command "xclip -selection clipboard" // x11
+// copy_command "wl-copy"                    // wayland
+// copy_command "pbcopy"                     // osx
+// 
+// copy_command "pbcopy"
+ 
+// Choose the destination for copied text
+// Allows using the primary selection buffer (on x11/wayland) instead of the system clipboard.
+// Does not apply when using copy_command.
+// Options:
+//   - system (default)
+//   - primary
+// 
+// copy_clipboard "primary"
+ 
+// Enable automatic copying (and clearing) of selection when releasing mouse
+// Default: true
+// 
+// copy_on_select true
+ 
+// Path to the default editor to use to edit pane scrollbuffer
+// Default: $EDITOR or $VISUAL
+// scrollback_editor "/usr/bin/vim"
+ 
+// A fixed name to always give the Zellij session.
+// Consider also setting `attach_to_session true,`
+// otherwise this will error if such a session exists.
+// Default: <RANDOM>
+// 
+// session_name "My singleton session"
+ 
+// When `session_name` is provided, attaches to that session
+// if it is already running or creates it otherwise.
+// Default: false
+// 
+// attach_to_session true
+ 
+// Toggle between having Zellij lay out panes according to a predefined set of layouts whenever possible
+// Options:
+//   - true (default)
+//   - false
+// 
+// auto_layout false
+ 
+// Whether sessions should be serialized to the cache folder (including their tabs/panes, cwds and running commands) so that they can later be resurrected
+// Options:
+//   - true (default)
+//   - false
+// 
+// session_serialization false
+ 
+// Whether pane viewports are serialized along with the session, default is false
+// Options:
+//   - true
+//   - false (default)
+// 
+// serialize_pane_viewport false
+ 
+// Scrollback lines to serialize along with the pane viewport when serializing sessions, 0
+// defaults to the scrollback size. If this number is higher than the scrollback size, it will
+// also default to the scrollback size. This does nothing if `serialize_pane_viewport` is not true.
+// 
+// scrollback_lines_to_serialize 10000
+ 
+// Enable or disable the rendering of styled and colored underlines (undercurl).
+// May need to be disabled for certain unsupported terminals
+// (Requires restart)
+// Default: true
+// 
+// styled_underlines false
+ 
+// How often in seconds sessions are serialized
+// 
+// serialization_interval 10000
+ 
+// Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
+// metadata info on this session)
+// (Requires restart)
+// Default: false
+// 
+// disable_session_metadata false
+ 
+// Enable or disable support for the enhanced Kitty Keyboard Protocol (the host terminal must also support it)
+// (Requires restart)
+// Default: true (if the host terminal supports it)
+// 
+// support_kitty_keyboard_protocol false
+// Whether to make sure a local web server is running when a new Zellij session starts.
+// This web server will allow creating new sessions and attaching to existing ones that have
+// opted in to being shared in the browser.
+// When enabled, navigate to http://127.0.0.1:8082
+// (Requires restart)
+// 
+// Note: a local web server can still be manually started from within a Zellij session or from the CLI.
+// If this is not desired, one can use a version of Zellij compiled without
+// `web_server_capability`
+// 
+// Possible values:
+// - true
+// - false
+// Default: false
+// 
+// web_server false
+// Whether to allow sessions started in the terminal to be shared through a local web server, assuming one is
+// running (see the `web_server` option for more details).
+// (Requires restart)
+// 
+// Note: This is an administrative separation and not intended as a security measure.
+// 
+// Possible values:
+// - "on" (allow web sharing through the local web server if it
+// is online)
+// - "off" (do not allow web sharing unless sessions explicitly opt-in to it)
+// - "disabled" (do not allow web sharing and do not permit sessions started in the terminal to opt-in to it)
+// Default: "off"
+// 
+// web_sharing "off"
+// A path to a certificate file to be used when setting up the web client to serve the
+// connection over HTTPs
+// 
+// web_server_cert "/path/to/cert.pem"
+// A path to a key file to be used when setting up the web client to serve the
+// connection over HTTPs
+// 
+// web_server_key "/path/to/key.pem"
+/// Whether to enforce https connections to the web server when it is bound to localhost
+/// (127.0.0.0/8)
+///
+/// Note: https is ALWAYS enforced when bound to non-local interfaces
+///
+/// Default: false
+// 
+// enforce_https_for_localhost false
+ 
+// Whether to stack panes when resizing beyond a certain size
+// Default: true
+// 
+// stacked_resize false
+ 
+// Whether to show tips on startup
+// Default: true
+// 
+// show_startup_tips false
+ 
+// Whether to show release notes on first version run
+// Default: true
+// 
+// show_release_notes false
+ 
+// Whether to enable mouse hover effects and pane grouping functionality
+// default is true
+// advanced_mouse_actions false
+ 
+// Whether to enable mouse hover visual effects (frame highlight and help text)
+// default is true
+// mouse_hover_effects false
+ 
+// Whether to show visual bell indicators (pane/tab frame flash and [!] suffix)
+// default is true
+// visual_bell true
+ 
+// Whether to focus panes on mouse hover
+// default is false
+// focus_follows_mouse false
+ 
+// Whether clicking a pane to focus it also sends the click into the pane
+// default is false
+// mouse_click_through false
+ 
+// The ip address the web server should listen on when it starts
+// Default: "127.0.0.1"
+// (Requires restart)
+// web_server_ip "127.0.0.1"
+ 
+// The port the web server should listen on when it starts
+// Default: 8082
+// (Requires restart)
+// web_server_port 8082
+ 
+// A command to run (will be wrapped with sh -c and provided the RESURRECT_COMMAND env variable) 
+// after Zellij attempts to discover a command inside a pane when resurrecting sessions, the STDOUT
+// of this command will be used instead of the discovered RESURRECT_COMMAND
+// can be useful for removing wrappers around commands
+// Note: be sure to escape backslashes and similar characters properly
+// post_command_discovery_hook "echo $RESURRECT_COMMAND | sed <your_regex_here>"
+
+// Number of async worker tasks to spawn per active client.
+//
+// Allocating few tasks may result in resource contention and lags. Small values (around 4) should
+// typically work best. Set to 0 to use the number of (physical) CPU cores.
+// Note: This only applies to web clients at the moment.
+// client_async_worker_tasks 4


### PR DESCRIPTION
## Summary
- add x86_64-linux / WSL home-manager configuration to the flake
- link Zellij and Windows Terminal dotfiles from home-manager
- add Zellij package/config and adjust Ghostty keybindings to pass through to Zellij

## Test
- nix run .#build