### PR TITLE
Sakura Cloud skill を global から外す

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -15,9 +15,6 @@ dependencies:
     - nananaman/skills/meta/reviewing-skills#5622e07c1bc2bd5872b5a174880a06a0b231251d
     - nananaman/skills/meta/review-diff-skill#5622e07c1bc2bd5872b5a174880a06a0b231251d
     - nananaman/skills/meta/review-skill#5622e07c1bc2bd5872b5a174880a06a0b231251d
-    - nananaman/skills/sakura-cloud/eventbus#13c1dbed3e9bf67b5a31b59ea300e7c8b20833d6
-    - nananaman/skills/sakura-cloud/webaccel#13c1dbed3e9bf67b5a31b59ea300e7c8b20833d6
-    - nananaman/skills/sakura-cloud/workflows#13c1dbed3e9bf67b5a31b59ea300e7c8b20833d6
     - nananaman/skills/writing/japanese-tech-writing#020883d61164cab6f68d53cb3c0529232784d15d
     - nananaman/skills/productivity/grill-me#5c1c1c71396b990542421930a025ce7dcf104ece
     - nananaman/skills/productivity/teach#d331688c0006ff84aa2cab16169229d5d7cbb8f2


### PR DESCRIPTION
## Summary
- Sakura Cloud 関連 skill を global APM manifest から外します。

## Changes
- `apm/apm.yml` から以下を削除
  - `nananaman/skills/sakura-cloud/eventbus`
  - `nananaman/skills/sakura-cloud/webaccel`
  - `nananaman/skills/sakura-cloud/workflows`

## Tests
- `rg -n 'sakura-cloud' apm/apm.yml` で manifest から削除済みであることを確認
- katohome 側では project-local APM に移す変更を別 PR 化予定

## Review notes
- Sakura Cloud skill は全 repo で常時有効にせず、利用 repo 側の project-local APM で有効化する方針です。
