### PR TITLE
empirical prompt tuning を global skill から外す

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -5,7 +5,6 @@ target: claude,agent-skills
 dependencies:
   apm:
     - mizchi/skills/retrospective-codify#f74212c0e3c2e1cf420d27c6418af1a10f697f4b
-    - mizchi/skills/meta/empirical-prompt-tuning#89c1b34018ba0d85a770c065ba22f83a8d004d34
     - nananaman/skills/engineering/create-pr#a477e09b3d6595bb27addfde15289813047466c7
     - nananaman/skills/meta/apm-usage#5622e07c1bc2bd5872b5a174880a06a0b231251d
     - nananaman/skills/engineering/review-diff-code#df8a88be0371d20eaf572142ebdb6a8158c7c67a
@@ -13,9 +12,9 @@ dependencies:
     - nananaman/skills/personal/chouge-git#0f419b091e798550d66d568a83d869691f75dddc
     - nananaman/skills/personal/chouge-changelog#9ecd9cbf2fdfaf2b00ae9b5a934919bef3ff5123
     - nananaman/skills/meta/create-skill#36fc5290c9ab9278fcb7415f408b7016baac1f88
-    - nananaman/skills/meta/reviewing-skills#36fc5290c9ab9278fcb7415f408b7016baac1f88
-    - nananaman/skills/meta/review-diff-skill#36fc5290c9ab9278fcb7415f408b7016baac1f88
-    - nananaman/skills/meta/review-skill#36fc5290c9ab9278fcb7415f408b7016baac1f88
+    - nananaman/skills/meta/reviewing-skills#70caff47c46e18c6f3b9d495fcc3b2279934d46e
+    - nananaman/skills/meta/review-diff-skill#70caff47c46e18c6f3b9d495fcc3b2279934d46e
+    - nananaman/skills/meta/review-skill#70caff47c46e18c6f3b9d495fcc3b2279934d46e
     - nananaman/skills/writing/japanese-tech-writing#020883d61164cab6f68d53cb3c0529232784d15d
     - nananaman/skills/productivity/grill-me#5c1c1c71396b990542421930a025ce7dcf104ece
     - nananaman/skills/productivity/teach#d331688c0006ff84aa2cab16169229d5d7cbb8f2


### PR DESCRIPTION
## Summary
- `empirical-prompt-tuning` を global skill から外します。
- skill review 系に不足分を取り込んだ `nananaman/skills` の commit へ pin を更新します。

## Changes
- `mizchi/skills/meta/empirical-prompt-tuning` の APM dependency を削除
- `reviewing-skills` / `review-diff-skill` / `review-skill` の pin を `70caff47c46e18c6f3b9d495fcc3b2279934d46e` に更新

## Tests
- `git diff --check`
- APM manifest diff を確認（削除 1 件、pin 更新 3 件のみ）
- `apm install -g` は未実行

## Review notes
- 対応する skills PR: https://github.com/nananaman/skills/pull/3
- skills PR の merge 後に適用する想定です。
