### PR TITLE
テスト記述スタイル skill を参照する

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -21,8 +21,7 @@
 - コメントは必要な箇所にのみ付け、自明なことは書かない
 
 ## テスト
-- Arrange, Act, Assert のコメントを入れて読みやすくする
-- 異常系のテストは正常系とは別の関数に分ける
+- テストを新規追加・修正・レビューするときは `test-writing-style` skill を使う
 
 ## 環境
 - GitHub: {{ .github_username }}

--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -8,6 +8,7 @@ dependencies:
     - nananaman/skills/engineering/create-pr#a477e09b3d6595bb27addfde15289813047466c7
     - nananaman/skills/meta/apm-usage#5622e07c1bc2bd5872b5a174880a06a0b231251d
     - nananaman/skills/engineering/review-diff-code#df8a88be0371d20eaf572142ebdb6a8158c7c67a
+    - nananaman/skills/engineering/test-writing-style#3288f12ad7ce58521fdc5f247ebcf946e53325d1
     - nananaman/skills/engineering/sandbox-runtime#5e85fe6e71c5907f784741a851ccdd77d80c9466
     - nananaman/skills/personal/chouge-git#0f419b091e798550d66d568a83d869691f75dddc
     - nananaman/skills/personal/chouge-changelog#9ecd9cbf2fdfaf2b00ae9b5a934919bef3ff5123


### PR DESCRIPTION
## 概要
- global agent instruction のテスト規約を `test-writing-style` skill 参照へ集約
- APM manifest に `nananaman/skills/engineering/test-writing-style` を full SHA pin で追加

## 関連 PR
- nananaman/skills#5

## Review notes
- review gate: `review-diff-skill` / `review-skill` 相当
- 対象: `agents/AGENTS.md`, `apm/apm.yml`
- 結果: 当初の finding（AGENTS.md 参照と APM manifest 未接続）は、`apm/apm.yml` への pin 追加で解消

## Tests
- `apm install -g` は実行したが失敗
  - 理由: 既存 dependency `nananaman/skills/productivity/grill-me#5c1c1c...` の content hash が lockfile と不一致
  - 今回追加した `test-writing-style` の取得前に中断したため、別途 lockfile / grill-me pin の整理が必要
