### PR TITLE
feat: TDD skill を global skills に追加する

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -8,7 +8,8 @@ dependencies:
     - nananaman/skills/engineering/create-pr#57fccf10a292978e3564a2e8087013a3b333e6d3
     - nananaman/skills/meta/apm-usage#5622e07c1bc2bd5872b5a174880a06a0b231251d
     - nananaman/skills/engineering/review-diff-code#df8a88be0371d20eaf572142ebdb6a8158c7c67a
-    - nananaman/skills/engineering/test-writing-style#3288f12ad7ce58521fdc5f247ebcf946e53325d1
+    - nananaman/skills/engineering/tdd#2b8f0ca6d149939950277402b60c3ccc0c038ff0
+    - nananaman/skills/engineering/test-writing-style#2b8f0ca6d149939950277402b60c3ccc0c038ff0
     - nananaman/skills/engineering/sandbox-runtime#5e85fe6e71c5907f784741a851ccdd77d80c9466
     - nananaman/skills/personal/chouge-git#0f419b091e798550d66d568a83d869691f75dddc
     - nananaman/skills/personal/chouge-changelog#9ecd9cbf2fdfaf2b00ae9b5a934919bef3ff5123


### PR DESCRIPTION
## Summary
- global agent skills に `tdd` skill を追加します。
- `test-writing-style` を TDD skill 追加 commit の SHA に更新します。

## Changes
- `apm/apm.yml`
  - `nananaman/skills/engineering/tdd#2b8f0ca6d149939950277402b60c3ccc0c038ff0` を追加。
  - `nananaman/skills/engineering/test-writing-style` を `2b8f0ca6d149939950277402b60c3ccc0c038ff0` に更新。

## Tests
- `apm install -g` を実行。
  - ただし現環境では `~/.apm` が通常 checkout の `dotfiles/apm` へ symlink されているため、この worktree 側の `apm/apm.yml` は参照されず、`tdd` skill は未展開。
- `~/.agents/skills/tdd`: missing
- `~/.claude/skills/tdd`: missing

## Review notes
- review gate: APM pin / manifest 差分レビューを実施。
- 確認内容:
  - `target: claude,agent-skills` が user-scope global skill 用として妥当。
  - 追加・更新 dependency は full SHA pin。
  - source-of-truth は `nananaman/skills`。
  - 対象 commit `2b8f0ca6d149939950277402b60c3ccc0c038ff0` は skills repo の `feature/engineering/tdd-skill` に存在。
  - `apm.lock.yaml` / `apm_modules` は差分に含まれていない。
- 結果: actionable finding なし。
