### PR TITLE
chore: apm-usage の pin を更新する

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -6,7 +6,7 @@ dependencies:
   apm:
     - mizchi/skills/retrospective-codify#f74212c0e3c2e1cf420d27c6418af1a10f697f4b
     - nananaman/skills/engineering/create-pr#57fccf10a292978e3564a2e8087013a3b333e6d3
-    - nananaman/skills/meta/apm-usage#5622e07c1bc2bd5872b5a174880a06a0b231251d
+    - nananaman/skills/meta/apm-usage#ad7bb60fa2aba572f1ebb695e8ad7b2b6a15861b
     - nananaman/skills/engineering/review-diff-code#df8a88be0371d20eaf572142ebdb6a8158c7c67a
     - nananaman/skills/engineering/test-writing-style#3288f12ad7ce58521fdc5f247ebcf946e53325d1
     - nananaman/skills/engineering/sandbox-runtime#5e85fe6e71c5907f784741a851ccdd77d80c9466


### PR DESCRIPTION
## Summary
- `apm-usage` skill の APM pin を、merge 済みの最新 commit に更新します。

## Changes
- `apm/apm.yml` の `nananaman/skills/meta/apm-usage` pin を `ad7bb60fa2aba572f1ebb695e8ad7b2b6a15861b` に更新。

## Tests
- `apm install -g --update`
- `grep -n "User-scope manifest path\|readlink ~/.apm\|apm install -g.*current" ~/.agents/skills/apm-usage/SKILL.md ~/.claude/skills/apm-usage/SKILL.md`

## Review notes
- Review gate: `review-diff-skill`
- Target: `apm/apm.yml` の APM pin 更新差分
- Result: actionable finding なし。
- `readlink ~/.apm` / `realpath ~/.apm/apm.yml` で user-scope manifest の実体が dotfiles 本体 repo の `apm/apm.yml` であることを確認済み。
