### PR TITLE
chore: review-diff-code の pin を更新する

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -7,7 +7,7 @@ dependencies:
     - mizchi/skills/retrospective-codify#f74212c0e3c2e1cf420d27c6418af1a10f697f4b
     - nananaman/skills/engineering/create-pr#57fccf10a292978e3564a2e8087013a3b333e6d3
     - nananaman/skills/meta/apm-usage#ad7bb60fa2aba572f1ebb695e8ad7b2b6a15861b
-    - nananaman/skills/engineering/review-diff-code#df8a88be0371d20eaf572142ebdb6a8158c7c67a
+    - nananaman/skills/engineering/review-diff-code#d0913ca06392e1d330502f01c6d80257e717610f
     - nananaman/skills/engineering/tdd#2b8f0ca6d149939950277402b60c3ccc0c038ff0
     - nananaman/skills/engineering/test-writing-style#2b8f0ca6d149939950277402b60c3ccc0c038ff0
     - nananaman/skills/engineering/sandbox-runtime#5e85fe6e71c5907f784741a851ccdd77d80c9466


### PR DESCRIPTION
## Summary
- global skill `review-diff-code` の APM pin を更新
- 5観点並列レビュー対応版を `apm install -g` で展開できるようにする

## Changes
- `apm/apm.yml` の `nananaman/skills/engineering/review-diff-code` 参照 SHA を更新
  - `df8a88be0371d20eaf572142ebdb6a8158c7c67a`
  - `d0913ca06392e1d330502f01c6d80257e717610f`

## Tests
- `apm install -g` は lockfile hash mismatch で停止
- `apm install -g --update` で成功
- 展開確認
  - `~/.agents/skills/review-diff-code/`
  - `~/.claude/skills/review-diff-code/`

## Review notes
- `review-diff-skill` + `apm-usage` 相当の APM pin 差分レビューを実施
  - full SHA pin であることを確認
  - `~/.apm` が dotfiles の `apm/` を指していることを確認
  - APM 0.14.2 の `target: claude,agent-skills` 形式を維持していることを確認
  - actionable finding なし
