### PR TITLE
chore: 教訓を反映した skill pin を更新する

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -5,8 +5,8 @@ target: claude,agent-skills
 dependencies:
   apm:
     - mizchi/skills/retrospective-codify#f74212c0e3c2e1cf420d27c6418af1a10f697f4b
-    - nananaman/skills/engineering/create-pr#57fccf10a292978e3564a2e8087013a3b333e6d3
-    - nananaman/skills/meta/apm-usage#ad7bb60fa2aba572f1ebb695e8ad7b2b6a15861b
+    - nananaman/skills/engineering/create-pr#12e17fdedf84b1810af5e274fe36713839ca6ebc
+    - nananaman/skills/meta/apm-usage#12e17fdedf84b1810af5e274fe36713839ca6ebc
     - nananaman/skills/engineering/review-diff-code#d0913ca06392e1d330502f01c6d80257e717610f
     - nananaman/skills/engineering/tdd#2b8f0ca6d149939950277402b60c3ccc0c038ff0
     - nananaman/skills/engineering/test-writing-style#2b8f0ca6d149939950277402b60c3ccc0c038ff0


### PR DESCRIPTION
## Summary
- `create-pr` と `apm-usage` の global skill pin を更新
- retrospective で得た教訓を反映した版を user-scope APM で展開できるようにする

## Changes
- `apm/apm.yml` の pin を更新
  - `nananaman/skills/engineering/create-pr#12e17fdedf84b1810af5e274fe36713839ca6ebc`
  - `nananaman/skills/meta/apm-usage#12e17fdedf84b1810af5e274fe36713839ca6ebc`

## Tests
- `apm install -g --update`
- 展開確認
  - `~/.agents/skills/apm-usage/SKILL.md`
  - `~/.agents/skills/create-pr/SKILL.md`
  - `~/.claude/skills/apm-usage/SKILL.md`
  - `~/.claude/skills/create-pr/SKILL.md`

## Review notes
- APM pin 差分レビューを実施
  - full SHA pin であることを確認
  - `~/.apm` が dotfiles の `apm/` を指していることを確認
  - APM 0.14.2 の `target: claude,agent-skills` 形式を維持していることを確認
  - actionable finding なし
