### PR TITLE
fix: nvim-treesitter の新 API に追従する

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -50,7 +50,7 @@ let
     pname = "dotfiles-secretlint";
     version = "0.0.0";
     src = ../../..;
-    npmDepsHash = "sha256-iHOgHl1G8JzG2OWvDiYUpL1GNIGdzNRqc2wPCQtYBYM=";
+    npmDepsHash = "sha256-1sVrc0S6G0p+ZWhFXFechDAMGy259J6Ziy8I427Hgks=";
     dontNpmBuild = true;
     installPhase = ''
       runHook preInstall
@@ -128,8 +128,10 @@ in
     # Development
     go
     deno
+    clang
     nixfmt
     neovim
+    tree-sitter
     secretlint
     apm-cli
     tmux

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -74,7 +74,12 @@ return {
   },
 
   -- TypeScript
-  { "windwp/nvim-ts-autotag" },
+  {
+    "windwp/nvim-ts-autotag",
+    config = function()
+      require("nvim-ts-autotag").setup()
+    end,
+  },
 
   -- Flutter
   {

--- a/nvim/lua/plugins/nvim-lsp.lua
+++ b/nvim/lua/plugins/nvim-lsp.lua
@@ -56,6 +56,18 @@ return {
       -- end
 
       -- flutter-tools
+      if vim.lsp.document_color then
+        vim.api.nvim_create_autocmd("LspAttach", {
+          group = vim.api.nvim_create_augroup("flutter-document-color", { clear = true }),
+          callback = function(event)
+            local client = vim.lsp.get_client_by_id(event.data.client_id)
+            if client and client.name == "dartls" then
+              vim.lsp.document_color.enable(true, { bufnr = event.buf })
+            end
+          end,
+        })
+      end
+
       require("flutter-tools").setup({
         ui = {
           notification_style = "plugin",
@@ -64,11 +76,6 @@ return {
           enabled = true,
         },
         lsp = {
-          color = {
-            enabled = true,
-            background = true,
-            virtual_text = false,
-          },
           on_attach = on_attach,
           -- capabilities = capabilities,
         },

--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -1,26 +1,65 @@
+local function register_custom_parsers()
+  require("nvim-treesitter.parsers").nu = {
+    install_info = {
+      url = "https://github.com/nushell/tree-sitter-nu",
+      revision = "348b787d8b0409091d85fe9d4eb007fe9f3406bb",
+      queries = "queries/nu",
+    },
+  }
+end
+
+local installing = {}
+
+local function has_value(values, target)
+  return vim.tbl_contains(values, target)
+end
+
+local function ensure_parser(treesitter, lang, bufnr)
+  if has_value(treesitter.get_installed("parsers"), lang) then
+    if bufnr then
+      pcall(vim.treesitter.start, bufnr, lang)
+    end
+    return
+  end
+
+  if not has_value(treesitter.get_available(), lang) or installing[lang] then
+    return
+  end
+
+  installing[lang] = true
+  treesitter.install({ lang }):await(function()
+    installing[lang] = nil
+    if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+      pcall(vim.treesitter.start, bufnr, lang)
+    end
+  end)
+end
+
 return {
   "nvim-treesitter/nvim-treesitter",
+  branch = "main",
   build = ":TSUpdate",
   config = function()
-    local configs = require("nvim-treesitter.configs")
+    register_custom_parsers()
 
-    configs.setup({
-      parser_install_dir = parser_install_dir,
-      highlight = {
-        enable = true,
-        -- disable = { "make", "env" },
-      },
-      autotag = {
-        enable = true,
-      },
-      matchup = {
-        enable = true, -- mandatory, false will disable the whole extension
-      },
-      auto_install = true,
-      ensure_installed = { "nu" },
+    vim.api.nvim_create_autocmd("User", {
+      group = vim.api.nvim_create_augroup("custom-treesitter-parsers", { clear = true }),
+      pattern = "TSUpdate",
+      callback = register_custom_parsers,
+    })
+
+    local treesitter = require("nvim-treesitter")
+
+    treesitter.setup()
+    ensure_parser(treesitter, "nu")
+
+    vim.api.nvim_create_autocmd("FileType", {
+      group = vim.api.nvim_create_augroup("treesitter-highlight", { clear = true }),
+      callback = function(args)
+        local lang = vim.treesitter.language.get_lang(args.match) or args.match
+
+        ensure_parser(treesitter, lang, args.buf)
+      end,
     })
   end,
-  dependencies = {
-    { "nushell/tree-sitter-nu", build = ":TSUpdate nu" },
-  },
 }


### PR DESCRIPTION
## Summary
- nvim-treesitter の `nvim-treesitter.configs` 旧 API 利用をやめ、現行の root API に追従します。
- Treesitter parser の自動 install / highlight 起動を FileType autocmd で維持します。
- Flutter tools の deprecated `lsp.color` 設定を Neovim 0.12 の document color API に移行します。
- `tree-sitter` parser build に必要な `tree-sitter` / `clang` を home packages に追加し、既存の `secretlint` npmDepsHash も更新します。

## Changes
- `nvim/lua/plugins/treesitter.lua`
  - `require("nvim-treesitter.configs")` を削除し、`require("nvim-treesitter").setup()` / `install()` に移行
  - `nvim-treesitter` を `main` branch に明示
  - `nu` parser を custom parser として登録し、revision を pin
  - missing parser を FileType 時に install してから `vim.treesitter.start()` する処理を追加
- `nvim/lua/plugins.lua`
  - `nvim-ts-autotag` を plugin 側の `setup()` で初期化
- `nvim/lua/plugins/nvim-lsp.lua`
  - Flutter tools の deprecated `lsp.color` を削除し、`dartls` attach 時に `vim.lsp.document_color.enable()` を使う
- `nix/modules/home/packages.nix`
  - `tree-sitter` と `clang` を追加
  - `secretlint` の `npmDepsHash` を現行 `package-lock.json` に合わせて更新

## Tests
- `nix run .#switch`
- `command -v tree-sitter && command -v cc && nvim --headless '+qa'`
- `nix run .#build`
- `nvim --headless '+Lazy load none-ls.nvim' '+qa'`

## Review notes
- Review gate: `~/.agents/skills/review-diff-code/scripts/review-diff-code --mode local`
- Round 1: accepted 2 / fixed 2（auto-install 維持、nvim-treesitter main branch 明示）
- Round 2: accepted 2 / fixed 2（nu parser revision pin、install lifecycle 統一）
- Round 3: accepted 0 / rejected 2 / all perspectives succeeded
  - `nu` parser registration / `files` 欠落の指摘は、現行 nvim-treesitter README の custom parser 登録例と、実際の `treesitter.get_available()` / install 成功で反証できるため rejected
