### PR TITLE
fix: Conform formatter 設定を整理する

### DIFF
--- a/nvim/lua/config/lsp.lua
+++ b/nvim/lua/config/lsp.lua
@@ -21,7 +21,6 @@ vim.api.nvim_create_autocmd("LspAttach", {
     -- vim.keymap.set({ "n", "v" }, "<space>ca", vim.lsp.buf.code_action, opts)
     -- vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)
     vim.keymap.set("n", "<space>f", function()
-      -- vim.lsp.buf.format({ async = true })
       require("conform").format()
     end, opts)
 

--- a/nvim/lua/plugins/conform.lua
+++ b/nvim/lua/plugins/conform.lua
@@ -2,18 +2,20 @@ return {
   "stevearc/conform.nvim",
   event = { "BufWritePre" },
   opts = {
-    format_on_save = {
-      -- These options will be passed to conform.format()
+    default_format_opts = {
       timeout_ms = 500,
       lsp_format = "fallback",
     },
+    format_on_save = {},
     formatters_by_ft = {
       lua = { "stylua" },
       python = { "isort", "ruff_format" },
       sql = { "sql_formatter" },
       go = { "golines", "gofmt" },
       toml = { "taplo" },
-      json = { "deno_fmt" },
+      json = { "oxfmt" },
+      jsonc = { "oxfmt" },
+      graphql = { "oxfmt" },
       -- You can customize some of the format options for the filetype (:help conform.format)
       -- rust = { "rustfmt", lsp_format = "fallback" },
       -- Conform will run the first available formatter

--- a/nvim/lua/plugins/mason-tool-installer.lua
+++ b/nvim/lua/plugins/mason-tool-installer.lua
@@ -1,0 +1,11 @@
+return {
+  "WhoIsSethDaniel/mason-tool-installer.nvim",
+  dependencies = {
+    "mason-org/mason.nvim",
+  },
+  opts = {
+    ensure_installed = {
+      "oxfmt",
+    },
+  },
+}

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -7,6 +7,6 @@
     "npm:@tintinweb/pi-subagents@0.10.3",
     "npm:@juicesharp/rpiv-ask-user-question@1.20.0"
   ],
-  "lastChangelogVersion": "0.79.9",
+  "lastChangelogVersion": "0.80.2",
   "theme": "dark"
 }


### PR DESCRIPTION
## Summary
- Conform の共通 format option を `default_format_opts` に寄せ、手動 format と保存時 format の設定重複をなくします。
- JSON / JSONC / GraphQL の formatter を `oxfmt` に統一します。
- Mason で `oxfmt` を宣言的に install するため `mason-tool-installer.nvim` を追加します。
- Pi agent の changelog version を更新します。

## Changes
- `nvim/lua/plugins/conform.lua`
  - `timeout_ms` / `lsp_format` を `default_format_opts` に移動
  - `format_on_save = {}` で default option を使う形に変更
  - `json` / `jsonc` / `graphql` を `oxfmt` に統一
- `nvim/lua/config/lsp.lua`
  - `<space>f` の手動 format も Conform の default option を使う形に変更
- `nvim/lua/plugins/mason-tool-installer.lua`
  - `oxfmt` の Mason install をコードで宣言
- `pi/agent/settings.json`
  - `lastChangelogVersion` を `0.80.2` に更新

## Tests
- `git diff --check`
- `python3 -m json.tool pi/agent/settings.json >/dev/null`
- `nvim --headless '+Lazy load conform.nvim' '+qa'`
  - 既存の `vim.tbl_flatten is deprecated` warning は出ますが、終了コードは成功

## Review notes
- Review gate: `~/.agents/skills/review-diff-code/scripts/review-diff-code --mode branch --base origin/main`
- Round 1: accepted 1 / fixed 1（format option 重複を `default_format_opts` に集約）
- Round 2: accepted 1 / fixed 1（formatter 実行バイナリの宣言を追加）
- Round 3: rejected 1 / fixed 1（`oxfmt` の GraphQL 対応指摘は Mason registry / oxfmt metadata で GraphQL 対応を確認し、`prettier` 変更を撤回）
- Round 4: rejected 2 / all perspectives succeeded
  - Mason と Conform の ownership split / Nix 管理への統一提案は、formatter 周辺を Mason 管理に寄せる方針と矛盾するため rejected
