### PR TITLE
APM skill pinを更新する

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -6,6 +6,13 @@ dependencies:
   apm:
     - mizchi/skills/retrospective-codify#f74212c0e3c2e1cf420d27c6418af1a10f697f4b
     - nananaman/skills/engineering/create-pr#12e17fdedf84b1810af5e274fe36713839ca6ebc
+    - nananaman/skills/engineering/setup-engineering-flow#187035b02c56027cdddb6edf82d54095e17a5f3a
+    - nananaman/skills/engineering/draft-prd#187035b02c56027cdddb6edf82d54095e17a5f3a
+    - nananaman/skills/engineering/polish-prd#187035b02c56027cdddb6edf82d54095e17a5f3a
+    - nananaman/skills/engineering/draft-design-doc#187035b02c56027cdddb6edf82d54095e17a5f3a
+    - nananaman/skills/engineering/polish-design-doc#187035b02c56027cdddb6edf82d54095e17a5f3a
+    - nananaman/skills/engineering/draft-issue#187035b02c56027cdddb6edf82d54095e17a5f3a
+    - nananaman/skills/engineering/polish-issue#187035b02c56027cdddb6edf82d54095e17a5f3a
     - nananaman/skills/meta/apm-usage#12e17fdedf84b1810af5e274fe36713839ca6ebc
     - nananaman/skills/engineering/review-diff-code#d0913ca06392e1d330502f01c6d80257e717610f
     - nananaman/skills/engineering/tdd#2b8f0ca6d149939950277402b60c3ccc0c038ff0
@@ -18,6 +25,7 @@ dependencies:
     - nananaman/skills/meta/review-diff-skill#70caff47c46e18c6f3b9d495fcc3b2279934d46e
     - nananaman/skills/meta/review-skill#70caff47c46e18c6f3b9d495fcc3b2279934d46e
     - nananaman/skills/writing/japanese-tech-writing#020883d61164cab6f68d53cb3c0529232784d15d
-    - nananaman/skills/productivity/grill-me#5c1c1c71396b990542421930a025ce7dcf104ece
+    - nananaman/skills/productivity/grilling#187035b02c56027cdddb6edf82d54095e17a5f3a
+    - nananaman/skills/productivity/grill-me#187035b02c56027cdddb6edf82d54095e17a5f3a
     - nananaman/skills/productivity/teach#d331688c0006ff84aa2cab16169229d5d7cbb8f2
     - nananaman/skills/productivity/handoff#1415bd1dbac806ae0f9968add3d152d8439a05e5

--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -4,8 +4,9 @@ target: claude,agent-skills
 
 dependencies:
   apm:
-    - mizchi/skills/retrospective-codify#f74212c0e3c2e1cf420d27c6418af1a10f697f4b
+    - nananaman/skills/meta/retrospective-codify#6fbec99f22e1f454ff294d5bbb4e5a1d693f36e8
     - nananaman/skills/engineering/create-pr#12e17fdedf84b1810af5e274fe36713839ca6ebc
+    - nananaman/skills/engineering/ast-grep-practice#00f3c9511c3deb2dcbd4023af018287dc30147cf
     - nananaman/skills/engineering/setup-engineering-flow#187035b02c56027cdddb6edf82d54095e17a5f3a
     - nananaman/skills/engineering/draft-prd#187035b02c56027cdddb6edf82d54095e17a5f3a
     - nananaman/skills/engineering/polish-prd#187035b02c56027cdddb6edf82d54095e17a5f3a


### PR DESCRIPTION
## Summary
- global APM manifest に未 pin の reusable skill を追加・更新します。
- `ast-grep-practice` を global skill として展開できるようにします。

## Changes
- `engineering/ast-grep-practice` を `apm/apm.yml` に追加。
- 既存の未反映 APM pin 更新を同じ manifest に含めています。
  - `retrospective-codify` の参照元更新
  - engineering flow 系 skill の追加
  - `grilling` / `grill-me` の pin 更新

## Tests
- `python3` で `apm/apm.yml` を YAML parse し、APM dependency が `owner/repo/path#full-sha` 形式であることを確認。
- `apm install -g` 実行済み。
- `~/.agents/skills/ast-grep-practice` と `~/.claude/skills/ast-grep-practice` の展開確認済み。

## Review notes
- review gate: `review-diff-skill`
- 対象: APM manifest の pin 更新
- 結果: actionable finding なし
- 備考: working tree に既存の未コミット変更 `nix/modules/home/packages.nix` がありますが、この PR には含めていません。
