### PR TITLE
完了報告前の review gate ルールを追加

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -12,6 +12,7 @@
 ## 開発スタイル
 - TDD で開発する（探索 → Red → Green → Refactoring）
 - KPI やカバレッジ目標が与えられたら、達成するまで試行する
+- コード・設定変更では、完了報告前に該当 review gate（通常は `review-diff-code`）を通し、採用指摘を修正して再確認する（理由: test だけでは設計・運用・security regression を拾い切れない）
 
 ## コード設計
 - 関心の分離を保つ


### PR DESCRIPTION
## Summary
- global agent instructions に、コード・設定変更では完了報告前に該当 review gate を通すルールを追加します。
- test だけでは拾い切れない設計・運用・security regression を防ぐための常時ルールです。

## Tests
- `git diff --check`
- `review-diff-skill` 手順で static check / fresh-agent smoke を実施

## Review notes
- Smoke: test/typecheck だけ通ったコード変更で、完了報告前に review gate を要求することを確認済み。
