### PR TITLE
spi 起動の pi を Herdr agent として報告する

### DIFF
--- a/nix/modules/home/programs/pi.nix
+++ b/nix/modules/home/programs/pi.nix
@@ -16,5 +16,9 @@ in
       config.lib.file.mkOutOfStoreSymlink "${piAgentDir}/extensions/rtk.ts";
     ".pi/agent/extensions/tirith-guard.ts".source =
       config.lib.file.mkOutOfStoreSymlink "${piAgentDir}/extensions/tirith-guard.ts";
+    ".pi/agent/extensions/herdr-agent-state.ts" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${piAgentDir}/extensions/herdr-agent-state.ts";
+      force = true;
+    };
   };
 }

--- a/pi/agent/extensions/README.md
+++ b/pi/agent/extensions/README.md
@@ -1,0 +1,21 @@
+# Pi extensions
+
+## `herdr-agent-state.ts`
+
+`herdr-agent-state.ts` is vendored from `herdr integration install pi` so that
+home-manager can install the Herdr Pi integration reproducibly.
+
+Update flow:
+
+1. Save the current vendored file.
+2. Run `herdr integration install pi` to generate the upstream integration.
+3. Copy `~/.pi/agent/extensions/herdr-agent-state.ts` to
+   `pi/agent/extensions/herdr-agent-state.ts`.
+4. Apply `herdr-agent-state.local.patch` from this directory.
+5. Regenerate `herdr-agent-state.local.patch` by diffing the generated upstream
+   file against the patched vendored file.
+6. Run the Pi extension smoke check and `nix run .#build`.
+
+The patch records dotfiles-owned behavior, including socket validation,
+TUI-session guarding, and shutdown state cleanup. Keep new local behavior in the
+patch so future Herdr updates have an explicit review boundary.

--- a/pi/agent/extensions/herdr-agent-state.local.patch
+++ b/pi/agent/extensions/herdr-agent-state.local.patch
@@ -1,0 +1,195 @@
+--- herdr-agent-state.upstream.ts
++++ herdr-agent-state.ts
+@@ -1,21 +1,50 @@
+-// installed by herdr
+-// managed by herdr; reinstalling or updating the integration overwrites this file.
+-// add custom hooks/plugins beside this file instead of editing it.
++// Vendored from `herdr integration install pi`.
++// Dotfiles owns this copy and home-manager links it into ~/.pi/agent/extensions.
++// To update: reinstall the Herdr pi integration, copy the generated file here,
++// and re-apply the local hardening below.
+ // HERDR_INTEGRATION_ID=pi
+ // HERDR_INTEGRATION_VERSION=3
+ // @ts-nocheck
+ 
++import { lstatSync } from "node:fs";
+ import { createConnection } from "node:net";
++import { isAbsolute, normalize, sep } from "node:path";
+ 
+ const HERDR_ENV = process.env.HERDR_ENV;
+ const socketPath = process.env.HERDR_SOCKET_PATH;
+ const paneId = process.env.HERDR_PANE_ID;
+ const source = "herdr:pi";
+ 
++// BEGIN local hardening: trust only the user's Herdr socket.
+ function enabled() {
+-  return HERDR_ENV === "1" && !!socketPath && !!paneId;
++  return HERDR_ENV === "1" && isTrustedSocketPath(socketPath) && !!paneId;
+ }
+ 
++function isTrustedSocketPath(path: string | undefined): boolean {
++  if (!path || !isAbsolute(path)) {
++    return false;
++  }
++
++  const home = process.env.HOME;
++  if (!home) {
++    return false;
++  }
++
++  const normalizedPath = normalize(path);
++  const herdrConfigDir = `${normalize(home)}${sep}.config${sep}herdr`;
++  if (normalizedPath !== `${herdrConfigDir}${sep}herdr.sock`) {
++    return false;
++  }
++
++  try {
++    const stat = lstatSync(normalizedPath);
++    return stat.isSocket() && stat.uid === process.getuid?.();
++  } catch {
++    return false;
++  }
++}
++// END local hardening.
++
+ function sendRequest(request: unknown): Promise<void> {
+   if (!enabled()) {
+     return Promise.resolve();
+@@ -91,13 +120,7 @@
+ }
+ 
+ function withSessionRef(params: Record<string, unknown>): Record<string, unknown> {
+-  if (currentAgentSessionPath) {
+-    return { ...params, agent_session_path: currentAgentSessionPath };
+-  }
+-  if (currentAgentSessionId) {
+-    return { ...params, agent_session_id: currentAgentSessionId };
+-  }
+-  return params;
++  return { ...params, ...currentSessionRef() };
+ }
+ 
+ function currentSessionRef(): Record<string, unknown> | undefined {
+@@ -159,11 +182,19 @@
+ 
+ let sendInFlight = false;
+ let queuedState: QueuedState | undefined;
++// BEGIN local hardening: avoid stale state reports after release.
++let acceptingStateReports = true;
++let activeDrain: Promise<void> | undefined;
++// END local hardening.
+ 
+ function queueState(state: AgentState, message?: string): void {
++  if (!acceptingStateReports) {
++    return;
++  }
++
+   queuedState = { state, message, seq: nextReportSeq() };
+   if (!sendInFlight) {
+-    void drainStateQueue();
++    activeDrain = drainStateQueue();
+   }
+ }
+ 
+@@ -174,7 +205,7 @@
+ 
+   sendInFlight = true;
+   try {
+-    while (queuedState) {
++    while (queuedState && acceptingStateReports) {
+       const next = queuedState;
+       queuedState = undefined;
+       await sendState(next.state, next.message, next.seq);
+@@ -182,8 +213,10 @@
+   } finally {
+     sendInFlight = false;
+     if (queuedState) {
+-      void drainStateQueue();
++      activeDrain = drainStateQueue();
++      return;
+     }
++    activeDrain = undefined;
+   }
+ }
+ 
+@@ -215,6 +248,8 @@
+   if (!enabled()) {
+     return;
+   }
++  acceptingStateReports = true;
++  queuedState = undefined;
+ 
+   let agentActive = false;
+   let retryHoldActive = false;
+@@ -234,6 +269,13 @@
+     }
+   }
+ 
++  // BEGIN local hardening: blocked UI must not cancel retry-failure transition.
++  function clearIdleTimer() {
++    clearTimer(idleTimer);
++    idleTimer = undefined;
++  }
++  // END local hardening.
++
+   function clearPendingTimers() {
+     clearTimer(idleTimer);
+     clearTimer(retryTimer);
+@@ -247,6 +289,20 @@
+     failureMessage = undefined;
+   }
+ 
++  function clearSessionState() {
++    rootSession = false;
++    agentActive = false;
++    blockedCount = 0;
++    blockedMessage = undefined;
++    lastState = undefined;
++    lastMessage = undefined;
++    acceptingStateReports = false;
++    queuedState = undefined;
++    activeDrain = undefined;
++    clearPendingTimers();
++    clearFailureState();
++  }
++
+   function desiredState() {
+     if (blockedCount > 0) {
+       return { state: "blocked" as const, message: blockedMessage };
+@@ -309,16 +365,22 @@
+       return;
+     }
+ 
+-    clearPendingTimers();
++    clearIdleTimer();
+     blockedCount += 1;
+     blockedMessage = data.label;
+     publishState();
+   });
+ 
+   pi.on("session_start", (_event, ctx) => {
+-    if (ctx?.hasUI !== true) {
++    // BEGIN local hardening: report only real terminal TUI sessions.
++    if (ctx?.mode !== "tui") {
++      clearSessionState();
+       return;
+     }
++    // END local hardening.
++    acceptingStateReports = true;
++    queuedState = undefined;
++    activeDrain = undefined;
+     rootSession = true;
+     updateSessionRef(ctx);
+     void reportSession();
+@@ -361,7 +423,11 @@
+     if (!rootSession) {
+       return;
+     }
++    acceptingStateReports = false;
++    queuedState = undefined;
+     clearPendingTimers();
++    await activeDrain;
+     await releaseAgent();
++    rootSession = false;
+   });
+ }

--- a/pi/agent/extensions/herdr-agent-state.ts
+++ b/pi/agent/extensions/herdr-agent-state.ts
@@ -1,0 +1,433 @@
+// Vendored from `herdr integration install pi`.
+// Dotfiles owns this copy and home-manager links it into ~/.pi/agent/extensions.
+// To update: reinstall the Herdr pi integration, copy the generated file here,
+// and re-apply the local hardening below.
+// HERDR_INTEGRATION_ID=pi
+// HERDR_INTEGRATION_VERSION=3
+// @ts-nocheck
+
+import { lstatSync } from "node:fs";
+import { createConnection } from "node:net";
+import { isAbsolute, normalize, sep } from "node:path";
+
+const HERDR_ENV = process.env.HERDR_ENV;
+const socketPath = process.env.HERDR_SOCKET_PATH;
+const paneId = process.env.HERDR_PANE_ID;
+const source = "herdr:pi";
+
+// BEGIN local hardening: trust only the user's Herdr socket.
+function enabled() {
+  return HERDR_ENV === "1" && isTrustedSocketPath(socketPath) && !!paneId;
+}
+
+function isTrustedSocketPath(path: string | undefined): boolean {
+  if (!path || !isAbsolute(path)) {
+    return false;
+  }
+
+  const home = process.env.HOME;
+  if (!home) {
+    return false;
+  }
+
+  const normalizedPath = normalize(path);
+  const herdrConfigDir = `${normalize(home)}${sep}.config${sep}herdr`;
+  if (normalizedPath !== `${herdrConfigDir}${sep}herdr.sock`) {
+    return false;
+  }
+
+  try {
+    const stat = lstatSync(normalizedPath);
+    return stat.isSocket() && stat.uid === process.getuid?.();
+  } catch {
+    return false;
+  }
+}
+// END local hardening.
+
+function sendRequest(request: unknown): Promise<void> {
+  if (!enabled()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      socket.destroy();
+      resolve();
+    };
+
+    const socket = createConnection(socketPath!);
+    socket.on("error", finish);
+    socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+    socket.on("data", finish);
+    socket.on("end", finish);
+    const timeout = setTimeout(finish, 500);
+    timeout.unref?.();
+  });
+}
+
+type AgentState = "working" | "blocked" | "idle";
+
+type QueuedState = {
+  state: AgentState;
+  message?: string;
+  seq: number;
+};
+
+const idleDebounceMs = parseDurationEnv("HERDR_PI_IDLE_DEBOUNCE_MS", 250);
+const retryGraceMs = parseDurationEnv("HERDR_PI_RETRY_GRACE_MS", 2500);
+const retryableErrorPattern =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+let reportSeq = Date.now() * 1000;
+let currentAgentSessionId: string | undefined;
+let currentAgentSessionPath: string | undefined;
+
+function nextReportSeq(): number {
+  reportSeq += 1;
+  return reportSeq;
+}
+
+function parseDurationEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function updateSessionRef(ctx: any): void {
+  try {
+    const file = ctx?.sessionManager?.getSessionFile?.();
+    currentAgentSessionPath =
+      typeof file === "string" && file.startsWith("/") ? file : undefined;
+  } catch {
+    currentAgentSessionPath = undefined;
+  }
+
+  try {
+    const id = ctx?.sessionManager?.getSessionId?.();
+    currentAgentSessionId = typeof id === "string" && id.length > 0 ? id : undefined;
+  } catch {
+    currentAgentSessionId = undefined;
+  }
+}
+
+function withSessionRef(params: Record<string, unknown>): Record<string, unknown> {
+  return { ...params, ...currentSessionRef() };
+}
+
+function currentSessionRef(): Record<string, unknown> | undefined {
+  if (currentAgentSessionPath) {
+    return { agent_session_path: currentAgentSessionPath };
+  }
+  if (currentAgentSessionId) {
+    return { agent_session_id: currentAgentSessionId };
+  }
+  return undefined;
+}
+
+function reportSession(): Promise<void> {
+  const sessionRef = currentSessionRef();
+  if (!sessionRef) {
+    return Promise.resolve();
+  }
+
+  return sendRequest({
+    id: `${source}:session:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+    method: "pane.report_agent_session",
+    params: {
+      pane_id: paneId,
+      source,
+      agent: "pi",
+      seq: nextReportSeq(),
+      ...sessionRef,
+    },
+  });
+}
+
+function sendState(state: AgentState, message?: string, seq = nextReportSeq()): Promise<void> {
+  return sendRequest({
+    id: `${source}:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+    method: "pane.report_agent",
+    params: withSessionRef({
+      pane_id: paneId,
+      source,
+      agent: "pi",
+      state,
+      message,
+      seq,
+    }),
+  });
+}
+
+function releaseAgent(): Promise<void> {
+  return sendRequest({
+    id: `${source}:release:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+    method: "pane.release_agent",
+    params: {
+      pane_id: paneId,
+      source,
+      agent: "pi",
+      seq: nextReportSeq(),
+    },
+  });
+}
+
+let sendInFlight = false;
+let queuedState: QueuedState | undefined;
+// BEGIN local hardening: avoid stale state reports after release.
+let acceptingStateReports = true;
+let activeDrain: Promise<void> | undefined;
+// END local hardening.
+
+function queueState(state: AgentState, message?: string): void {
+  if (!acceptingStateReports) {
+    return;
+  }
+
+  queuedState = { state, message, seq: nextReportSeq() };
+  if (!sendInFlight) {
+    activeDrain = drainStateQueue();
+  }
+}
+
+async function drainStateQueue(): Promise<void> {
+  if (sendInFlight) {
+    return;
+  }
+
+  sendInFlight = true;
+  try {
+    while (queuedState && acceptingStateReports) {
+      const next = queuedState;
+      queuedState = undefined;
+      await sendState(next.state, next.message, next.seq);
+    }
+  } finally {
+    sendInFlight = false;
+    if (queuedState) {
+      activeDrain = drainStateQueue();
+      return;
+    }
+    activeDrain = undefined;
+  }
+}
+
+function lastAssistantMessage(messages: unknown[]): any | undefined {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i] as any;
+    if (message?.role === "assistant") {
+      return message;
+    }
+  }
+  return undefined;
+}
+
+function retryableErrorMessage(event: any): string | undefined {
+  const messages = Array.isArray(event?.messages) ? event.messages : [];
+  const assistant = lastAssistantMessage(messages);
+  if (assistant?.stopReason !== "error") {
+    return undefined;
+  }
+
+  const errorMessage = String(assistant.errorMessage ?? "");
+  if (!retryableErrorPattern.test(errorMessage)) {
+    return undefined;
+  }
+  return errorMessage || "retryable provider error";
+}
+
+export default function (pi) {
+  if (!enabled()) {
+    return;
+  }
+  acceptingStateReports = true;
+  queuedState = undefined;
+
+  let agentActive = false;
+  let retryHoldActive = false;
+  let failureBlocked = false;
+  let failureMessage: string | undefined;
+  let blockedCount = 0;
+  let blockedMessage: string | undefined;
+  let lastState: AgentState | undefined;
+  let lastMessage: string | undefined;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let rootSession = false;
+
+  function clearTimer(timer: ReturnType<typeof setTimeout> | undefined) {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+
+  // BEGIN local hardening: blocked UI must not cancel retry-failure transition.
+  function clearIdleTimer() {
+    clearTimer(idleTimer);
+    idleTimer = undefined;
+  }
+  // END local hardening.
+
+  function clearPendingTimers() {
+    clearTimer(idleTimer);
+    clearTimer(retryTimer);
+    idleTimer = undefined;
+    retryTimer = undefined;
+  }
+
+  function clearFailureState() {
+    retryHoldActive = false;
+    failureBlocked = false;
+    failureMessage = undefined;
+  }
+
+  function clearSessionState() {
+    rootSession = false;
+    agentActive = false;
+    blockedCount = 0;
+    blockedMessage = undefined;
+    lastState = undefined;
+    lastMessage = undefined;
+    acceptingStateReports = false;
+    queuedState = undefined;
+    activeDrain = undefined;
+    clearPendingTimers();
+    clearFailureState();
+  }
+
+  function desiredState() {
+    if (blockedCount > 0) {
+      return { state: "blocked" as const, message: blockedMessage };
+    }
+    if (failureBlocked) {
+      return { state: "blocked" as const, message: failureMessage };
+    }
+    if (agentActive || retryHoldActive) {
+      return { state: "working" as const, message: undefined };
+    }
+    return { state: "idle" as const, message: undefined };
+  }
+
+  function publishState(force = false) {
+    const next = desiredState();
+    if (!force && next.state === lastState && next.message === lastMessage) {
+      return;
+    }
+    lastState = next.state;
+    lastMessage = next.message;
+    queueState(next.state, next.message);
+  }
+
+  function scheduleIdle() {
+    clearPendingTimers();
+    clearFailureState();
+    idleTimer = setTimeout(() => {
+      idleTimer = undefined;
+      publishState();
+    }, idleDebounceMs);
+    idleTimer.unref?.();
+  }
+
+  function holdForRetry(message: string) {
+    clearPendingTimers();
+    retryHoldActive = true;
+    failureBlocked = false;
+    failureMessage = message;
+    publishState();
+
+    retryTimer = setTimeout(() => {
+      retryTimer = undefined;
+      retryHoldActive = false;
+      failureBlocked = true;
+      publishState();
+    }, retryGraceMs);
+    retryTimer.unref?.();
+  }
+
+  pi.events.on("herdr:blocked", (data) => {
+    if (!rootSession) {
+      return;
+    }
+    if (!data?.active) {
+      blockedCount = Math.max(0, blockedCount - 1);
+      if (blockedCount === 0) {
+        blockedMessage = undefined;
+      }
+      publishState();
+      return;
+    }
+
+    clearIdleTimer();
+    blockedCount += 1;
+    blockedMessage = data.label;
+    publishState();
+  });
+
+  pi.on("session_start", (_event, ctx) => {
+    // BEGIN local hardening: report only real terminal TUI sessions.
+    if (ctx?.mode !== "tui") {
+      clearSessionState();
+      return;
+    }
+    // END local hardening.
+    acceptingStateReports = true;
+    queuedState = undefined;
+    activeDrain = undefined;
+    rootSession = true;
+    updateSessionRef(ctx);
+    void reportSession();
+    publishState(true);
+  });
+
+  pi.on("agent_start", () => {
+    if (!rootSession) {
+      return;
+    }
+    clearPendingTimers();
+    clearFailureState();
+    agentActive = true;
+    publishState();
+  });
+
+  pi.on("agent_end", (event) => {
+    if (!rootSession) {
+      return;
+    }
+    if (!agentActive) {
+      // Pi can emit duplicate/late end events while auto-retry is already
+      // holding the pane in Working. Do not let an unqualified duplicate end
+      // cancel the retry hold and publish a false Idle.
+      return;
+    }
+
+    agentActive = false;
+
+    const retryableMessage = retryableErrorMessage(event);
+    if (retryableMessage) {
+      holdForRetry(retryableMessage);
+      return;
+    }
+
+    scheduleIdle();
+  });
+
+  pi.on("session_shutdown", async () => {
+    if (!rootSession) {
+      return;
+    }
+    acceptingStateReports = false;
+    queuedState = undefined;
+    clearPendingTimers();
+    await activeDrain;
+    await releaseAgent();
+    rootSession = false;
+  });
+}


### PR DESCRIPTION
## Summary
- `spi` / `srt` 経由で起動した `pi` を Herdr の agents section に表示できるようにする
- Herdr の Pi integration を dotfiles 管理に vendoring し、home-manager で `~/.pi/agent/extensions` に配置する
- vendored integration の更新手順と dotfiles 側 hardening patch を追加する

## Changes
- `herdr-agent-state.ts` を追加し、Pi extension から Herdr に agent state / session を報告
- Herdr socket path の検証、TUI session guard、shutdown 時の stale state report 対策を追加
- `nix/modules/home/programs/pi.nix` で Herdr Pi integration を symlink 配置
- `pi/agent/extensions/README.md` と `herdr-agent-state.local.patch` で vendored file の更新境界を明文化

## Tests
- `pi -e pi/agent/extensions/herdr-agent-state.ts --list-models`
- `zsh tests/spiw.test.zsh`
- `nix run .#build`
- Herdr pane 内で `spi` を起動し、`herdr pane list` / `herdr agent list` に `agent: pi` として出ることを確認

## Review notes
- template なし
- review gate: `~/.agents/skills/review-diff-code/scripts/review-diff-code --mode branch --base origin/main`
- Round 1-3: lifecycle / shutdown / vendored ownership の指摘を採用して修正
- Final round: 全 5 観点 success、No actionable findings

## Notes
- ローカル working tree には、この PR に含めていない既存の未コミット変更（`git/ignore`, `herdr/config.toml`）があります。
