### PR TITLE
Hunkレビュー導線をskill側へ移す

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -6,7 +6,6 @@
 - PR title / body / reviewer 向け説明は、ユーザーから別指定がない限り日本語で書く
 - Write PR titles, PR descriptions, and reviewer-facing explanations in Japanese unless the user explicitly asks for another language.
 - 不明瞭な指示は質問して明確にする
-- 「レビューさせて」「見せて」など、agent がレビューするのか人間がレビューするために Hunk 等で表示するのか曖昧な依頼では、レビュー tool を起動する前に主体を確認する
 - project の `AGENTS.md` や `CLAUDE.md` がある場合は、その追加指示も尊重する
 
 ## 開発スタイル


### PR DESCRIPTION
## Summary
- global AGENTS.md から「レビューさせて / 見せて」の主体確認ルールを削除
- Hunk 人間レビューの routing は `hunk-human-review` skill 側へ移す前提に整理

## Tests
- 未実行（agent instruction の 1 行削除のみ）

## Review notes
- 対応する skill 変更: nananaman/skills#29
- unrelated な未コミット変更（`herdr/config.toml`, `pi/agent/settings.json`）はこの PR に含めていない
