### PR TITLE
feat(herdr): Hunkレビューpluginを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ result
 
 # Node.js
 node_modules/
+__pycache__/
 
 # Secrets
 zsh/conf.d/local.zsh

--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -17,7 +17,6 @@ dependencies:
     - path: ~/ghq/github.com/nananaman/skills/meta/apm-usage
     - path: ~/ghq/github.com/nananaman/skills/meta/update-skills
     - path: ~/ghq/github.com/nananaman/skills/engineering/review-diff-code
-    - path: ~/ghq/github.com/nananaman/skills/engineering/hunk-human-review
     - path: ~/ghq/github.com/nananaman/skills/engineering/tdd
     - path: ~/ghq/github.com/nananaman/skills/engineering/test-writing-style
     - path: ~/ghq/github.com/nananaman/skills/engineering/sandbox-runtime

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
     let
       darwinUsername = "juntawatanabe";
       darwinHomedir = "/Users/${darwinUsername}";
-      darwinDotfilesDir = "${darwinHomedir}/ghq/github.com/chouge/dotfiles";
+      darwinDotfilesDir = "${darwinHomedir}/ghq/github.com/nananaman/dotfiles";
 
       wslUsername = "chouge";
       wslHomedir = "/home/${wslUsername}";

--- a/herdr-plugins/hunk-review/herdr-plugin.toml
+++ b/herdr-plugins/hunk-review/herdr-plugin.toml
@@ -1,0 +1,48 @@
+id = "hunk-review"
+name = "Hunk Review"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+description = "Open or focus locally managed Hunk reviews."
+platforms = ["linux", "macos"]
+
+[[actions]]
+id = "worktree-split"
+title = "Hunk worktree diff in split"
+contexts = ["pane", "workspace"]
+command = ["python3", "hunk_review.py", "open", "worktree", "split"]
+
+[[actions]]
+id = "worktree-tab"
+title = "Hunk worktree diff in tab"
+contexts = ["pane", "workspace"]
+command = ["python3", "hunk_review.py", "open", "worktree", "tab"]
+
+[[actions]]
+id = "worktree-popup"
+title = "Hunk worktree diff in popup"
+contexts = ["pane", "workspace"]
+command = ["python3", "hunk_review.py", "open", "worktree", "popup"]
+
+[[actions]]
+id = "branch-split"
+title = "Hunk branch diff in split"
+contexts = ["pane", "workspace"]
+command = ["python3", "hunk_review.py", "open", "branch", "split"]
+
+[[actions]]
+id = "branch-tab"
+title = "Hunk branch diff in tab"
+contexts = ["pane", "workspace"]
+command = ["python3", "hunk_review.py", "open", "branch", "tab"]
+
+[[actions]]
+id = "branch-popup"
+title = "Hunk branch diff in popup"
+contexts = ["pane", "workspace"]
+command = ["python3", "hunk_review.py", "open", "branch", "popup"]
+
+[[panes]]
+id = "review"
+title = "Hunk review"
+placement = "split"
+command = ["python3", "hunk_review.py", "run"]

--- a/herdr-plugins/hunk-review/herdr-plugin.toml
+++ b/herdr-plugins/hunk-review/herdr-plugin.toml
@@ -2,7 +2,7 @@ id = "hunk-review"
 name = "Hunk Review"
 version = "0.1.0"
 min_herdr_version = "0.7.0"
-description = "Open or focus locally managed Hunk reviews."
+description = "Open locally managed Hunk reviews."
 platforms = ["linux", "macos"]
 
 [[actions]]

--- a/herdr-plugins/hunk-review/hunk_review.py
+++ b/herdr-plugins/hunk-review/hunk_review.py
@@ -81,8 +81,10 @@ class PaneState:
         self.path = path
 
     @staticmethod
-    def _key(workspace_id: str, mode: str, placement: str) -> str:
-        return f"{workspace_id}:{mode}:{placement}"
+    def _key(workspace_id: str, repo: Path, mode: str, placement: str) -> str:
+        return json.dumps(
+            [workspace_id, str(repo), mode, placement], separators=(",", ":")
+        )
 
     def _read(self) -> dict[str, str]:
         try:
@@ -91,22 +93,33 @@ class PaneState:
             return {}
         return payload if isinstance(payload, dict) else {}
 
-    def get(self, workspace_id: str, mode: str, placement: str) -> str | None:
-        value = self._read().get(self._key(workspace_id, mode, placement))
+    def get(
+        self, workspace_id: str, repo: Path, mode: str, placement: str
+    ) -> str | None:
+        value = self._read().get(self._key(workspace_id, repo, mode, placement))
         return value if isinstance(value, str) else None
 
-    def set(self, workspace_id: str, mode: str, placement: str, pane_id: str) -> None:
+    def set(
+        self,
+        workspace_id: str,
+        repo: Path,
+        mode: str,
+        placement: str,
+        pane_id: str,
+    ) -> None:
         payload = self._read()
-        payload[self._key(workspace_id, mode, placement)] = pane_id
+        payload[self._key(workspace_id, repo, mode, placement)] = pane_id
         self.path.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.path.with_suffix(".tmp")
         temporary.write_text(json.dumps(payload, sort_keys=True) + "\n")
         os.chmod(temporary, 0o600)
         temporary.replace(self.path)
 
-    def remove(self, workspace_id: str, mode: str, placement: str) -> None:
+    def remove(
+        self, workspace_id: str, repo: Path, mode: str, placement: str
+    ) -> None:
         payload = self._read()
-        payload.pop(self._key(workspace_id, mode, placement), None)
+        payload.pop(self._key(workspace_id, repo, mode, placement), None)
         if not payload:
             self.path.unlink(missing_ok=True)
             return
@@ -225,18 +238,18 @@ def open_review(
         raise PluginError(f"unsupported review placement: {placement}")
 
     if placement != "popup":
-        pane_id = state.get(context.workspace_id, mode, placement)
+        pane_id = state.get(context.workspace_id, context.cwd, mode, placement)
         if pane_id:
             try:
                 pane = herdr.json(["pane", "get", pane_id])
             except PluginError:
-                state.remove(context.workspace_id, mode, placement)
+                state.remove(context.workspace_id, context.cwd, mode, placement)
             else:
                 workspace_id = pane.get("result", {}).get("pane", {}).get("workspace_id")
                 if workspace_id == context.workspace_id:
                     herdr.json(["plugin", "pane", "focus", pane_id])
                     return pane_id
-                state.remove(context.workspace_id, mode, placement)
+                state.remove(context.workspace_id, context.cwd, mode, placement)
 
     if placement == "split":
         opened = herdr.json(
@@ -258,7 +271,7 @@ def open_review(
             raise PluginError("Herdr did not return a managed pane id")
         herdr.json(["pane", "rename", pane_id, "hunk"])
         herdr.json(["pane", "run", pane_id, _run_command(mode, context.cwd, git)])
-        state.set(context.workspace_id, mode, placement, pane_id)
+        state.set(context.workspace_id, context.cwd, mode, placement, pane_id)
         return pane_id
 
     opened = herdr.json(_open_args(mode, placement, context))
@@ -268,7 +281,7 @@ def open_review(
     pane_id = _pane_from(opened)
     if pane_id is None:
         raise PluginError("Herdr did not return a managed pane id")
-    state.set(context.workspace_id, mode, placement, pane_id)
+    state.set(context.workspace_id, context.cwd, mode, placement, pane_id)
     return pane_id
 
 

--- a/herdr-plugins/hunk-review/hunk_review.py
+++ b/herdr-plugins/hunk-review/hunk_review.py
@@ -237,7 +237,7 @@ def open_review(
     if placement not in {"split", "tab", "popup"}:
         raise PluginError(f"unsupported review placement: {placement}")
 
-    if placement != "popup":
+    if placement not in {"popup", "split"}:
         pane_id = state.get(context.workspace_id, context.cwd, mode, placement)
         if pane_id:
             try:
@@ -271,7 +271,6 @@ def open_review(
             raise PluginError("Herdr did not return a managed pane id")
         herdr.json(["pane", "rename", pane_id, "hunk"])
         herdr.json(["pane", "run", pane_id, _run_command(mode, context.cwd, git)])
-        state.set(context.workspace_id, context.cwd, mode, placement, pane_id)
         return pane_id
 
     opened = herdr.json(_open_args(mode, placement, context))

--- a/herdr-plugins/hunk-review/hunk_review.py
+++ b/herdr-plugins/hunk-review/hunk_review.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Protocol
+
+
+class PluginError(RuntimeError):
+    pass
+
+
+class GitOutput(Protocol):
+    def output(self, repo: Path, args: list[str]) -> str | None: ...
+
+
+class HerdrClient(Protocol):
+    def json(self, args: list[str]) -> dict: ...
+
+
+@dataclass(frozen=True)
+class ReviewContext:
+    workspace_id: str
+    pane_id: str
+    cwd: Path
+
+
+class SubprocessGit:
+    def output(self, repo: Path, args: list[str]) -> str | None:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            return None
+        value = result.stdout.strip()
+        return value or None
+
+
+def _parse_herdr_output(output: str) -> dict:
+    if not output.strip():
+        return {}
+    for line in reversed(output.splitlines()):
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    raise PluginError("Herdr returned invalid JSON")
+
+
+class SubprocessHerdr:
+    def __init__(self, executable: str):
+        self.executable = executable
+
+    def json(self, args: list[str]) -> dict:
+        result = subprocess.run(
+            [self.executable, *args],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip()
+            raise PluginError(message or f"Herdr command failed: {' '.join(args)}")
+        return _parse_herdr_output(result.stdout)
+
+
+class PaneState:
+    def __init__(self, path: Path):
+        self.path = path
+
+    @staticmethod
+    def _key(workspace_id: str, mode: str, placement: str) -> str:
+        return f"{workspace_id}:{mode}:{placement}"
+
+    def _read(self) -> dict[str, str]:
+        try:
+            payload = json.loads(self.path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def get(self, workspace_id: str, mode: str, placement: str) -> str | None:
+        value = self._read().get(self._key(workspace_id, mode, placement))
+        return value if isinstance(value, str) else None
+
+    def set(self, workspace_id: str, mode: str, placement: str, pane_id: str) -> None:
+        payload = self._read()
+        payload[self._key(workspace_id, mode, placement)] = pane_id
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload, sort_keys=True) + "\n")
+        os.chmod(temporary, 0o600)
+        temporary.replace(self.path)
+
+    def remove(self, workspace_id: str, mode: str, placement: str) -> None:
+        payload = self._read()
+        payload.pop(self._key(workspace_id, mode, placement), None)
+        if not payload:
+            self.path.unlink(missing_ok=True)
+            return
+        self.path.write_text(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def review_context(env: Mapping[str, str], git: GitOutput) -> ReviewContext:
+    try:
+        payload = json.loads(env.get("HERDR_PLUGIN_CONTEXT_JSON", "{}"))
+    except json.JSONDecodeError as error:
+        raise PluginError("invalid Herdr plugin context") from error
+
+    workspace_id = payload.get("workspace_id") or env.get("HERDR_WORKSPACE_ID")
+    pane_id = payload.get("focused_pane_id") or env.get("HERDR_PANE_ID")
+    cwd = (
+        payload.get("focused_pane_cwd")
+        or payload.get("workspace_cwd")
+        or env.get("PWD")
+    )
+    if not isinstance(workspace_id, str) or not workspace_id:
+        raise PluginError("missing Herdr workspace id")
+    if not isinstance(pane_id, str) or not pane_id:
+        raise PluginError("missing focused Herdr pane id")
+    if not isinstance(cwd, str) or not cwd:
+        raise PluginError("missing focused pane cwd")
+
+    repo = git.output(Path(cwd), ["rev-parse", "--show-toplevel"])
+    if repo is None:
+        raise PluginError(f"not a Git repository: {cwd}")
+    return ReviewContext(workspace_id, pane_id, Path(repo))
+
+
+def build_hunk_argv(mode: str, repo: Path, git: GitOutput) -> list[str]:
+    if mode == "worktree":
+        return ["hunk", "diff", "--watch", "--no-transparent-bg"]
+
+    upstream = git.output(
+        repo,
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    )
+    comparison_ref = upstream or "origin/main"
+    if git.output(repo, ["rev-parse", "--verify", comparison_ref]) is None:
+        raise PluginError("unable to resolve a branch comparison ref")
+
+    return [
+        "hunk",
+        "diff",
+        f"{comparison_ref}...HEAD",
+        "--watch",
+        "--no-transparent-bg",
+    ]
+
+
+def _pane_from(payload: object) -> str | None:
+    if isinstance(payload, dict):
+        pane_id = payload.get("pane_id")
+        if isinstance(pane_id, str):
+            return pane_id
+        for value in payload.values():
+            found = _pane_from(value)
+            if found:
+                return found
+    if isinstance(payload, list):
+        for value in payload:
+            found = _pane_from(value)
+            if found:
+                return found
+    return None
+
+
+def _open_args(mode: str, placement: str, context: ReviewContext) -> list[str]:
+    args = [
+        "plugin",
+        "pane",
+        "open",
+        "--plugin",
+        "hunk-review",
+        "--entrypoint",
+        "review",
+        "--placement",
+        placement,
+        "--workspace",
+        context.workspace_id,
+    ]
+    if placement in {"split", "popup"}:
+        args.extend(["--target-pane", context.pane_id])
+    if placement == "split":
+        args.extend(["--direction", "right"])
+    args.extend(
+        [
+            "--cwd",
+            str(context.cwd),
+            "--env",
+            f"HUNK_REVIEW_MODE={mode}",
+            "--focus",
+        ]
+    )
+    return args
+
+
+def _run_command(mode: str, repo: Path, git: GitOutput) -> str:
+    return shlex.join(["exec", *build_hunk_argv(mode, repo, git)])
+
+
+def open_review(
+    mode: str,
+    placement: str,
+    context: ReviewContext,
+    herdr: HerdrClient,
+    state: PaneState,
+    git: GitOutput,
+) -> str | None:
+    if mode not in {"worktree", "branch"}:
+        raise PluginError(f"unsupported review mode: {mode}")
+    if placement not in {"split", "tab", "popup"}:
+        raise PluginError(f"unsupported review placement: {placement}")
+
+    if placement != "popup":
+        pane_id = state.get(context.workspace_id, mode, placement)
+        if pane_id:
+            try:
+                pane = herdr.json(["pane", "get", pane_id])
+            except PluginError:
+                state.remove(context.workspace_id, mode, placement)
+            else:
+                workspace_id = pane.get("result", {}).get("pane", {}).get("workspace_id")
+                if workspace_id == context.workspace_id:
+                    herdr.json(["plugin", "pane", "focus", pane_id])
+                    return pane_id
+                state.remove(context.workspace_id, mode, placement)
+
+    if placement == "split":
+        opened = herdr.json(
+            [
+                "pane",
+                "split",
+                context.pane_id,
+                "--direction",
+                "right",
+                "--cwd",
+                str(context.cwd),
+                "--env",
+                f"HUNK_REVIEW_MODE={mode}",
+                "--focus",
+            ]
+        )
+        pane_id = _pane_from(opened)
+        if pane_id is None:
+            raise PluginError("Herdr did not return a managed pane id")
+        herdr.json(["pane", "rename", pane_id, "hunk"])
+        herdr.json(["pane", "run", pane_id, _run_command(mode, context.cwd, git)])
+        state.set(context.workspace_id, mode, placement, pane_id)
+        return pane_id
+
+    opened = herdr.json(_open_args(mode, placement, context))
+    if placement == "popup":
+        return None
+
+    pane_id = _pane_from(opened)
+    if pane_id is None:
+        raise PluginError("Herdr did not return a managed pane id")
+    state.set(context.workspace_id, mode, placement, pane_id)
+    return pane_id
+
+
+def _run_hunk(mode: str, git: GitOutput) -> None:
+    repo = git.output(Path.cwd(), ["rev-parse", "--show-toplevel"])
+    if repo is None:
+        raise PluginError(f"not a Git repository: {Path.cwd()}")
+    argv = build_hunk_argv(mode, Path(repo), git)
+    os.chdir(repo)
+    os.execvp(argv[0], argv)
+
+
+def main(argv: list[str], env: Mapping[str, str]) -> int:
+    try:
+        if len(argv) == 3 and argv[0] == "open":
+            _, mode, placement = argv
+            if shutil.which("hunk") is None:
+                raise PluginError("hunk executable was not found")
+            git = SubprocessGit()
+            context = review_context(env, git)
+            herdr = SubprocessHerdr(env.get("HERDR_BIN_PATH", "herdr"))
+            state_dir = env.get("HERDR_PLUGIN_STATE_DIR")
+            if not state_dir:
+                raise PluginError("missing Herdr plugin state directory")
+            open_review(
+                mode,
+                placement,
+                context,
+                herdr,
+                PaneState(Path(state_dir) / "panes.json"),
+                git,
+            )
+            return 0
+
+        if argv == ["run"]:
+            mode = env.get("HUNK_REVIEW_MODE", "")
+            if mode not in {"worktree", "branch"}:
+                raise PluginError(f"unsupported review mode: {mode}")
+            _run_hunk(mode, SubprocessGit())
+            return 0
+
+        raise PluginError("usage: hunk_review.py open <worktree|branch> <split|tab|popup> | run")
+    except PluginError as error:
+        print(f"hunk-review: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:], os.environ))

--- a/herdr-plugins/hunk-review/hunk_review_test.py
+++ b/herdr-plugins/hunk-review/hunk_review_test.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+import hunk_review
+
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+REPO_DIR = PLUGIN_DIR.parents[1]
+
+
+class FakeGit:
+    def __init__(self, responses: dict[tuple[str, ...], str | None]):
+        self.responses = responses
+        self.calls: list[tuple[str, ...]] = []
+
+    def output(self, repo: Path, args: list[str]) -> str | None:
+        self.calls.append(tuple(args))
+        return self.responses.get(tuple(args))
+
+
+class FakeHerdr:
+    def __init__(self, responses: dict[tuple[str, ...], dict]):
+        self.responses = responses
+        self.calls: list[tuple[str, ...]] = []
+
+    def json(self, args: list[str]) -> dict:
+        key = tuple(args)
+        self.calls.append(key)
+        if key not in self.responses:
+            raise AssertionError(f"unexpected Herdr call: {key}")
+        return self.responses[key]
+
+
+class ParseHerdrOutputTest(unittest.TestCase):
+    def test_accepts_empty_success_output(self) -> None:
+        # Arrange
+        output = "\n"
+
+        # Act
+        payload = hunk_review._parse_herdr_output(output)
+
+        # Assert
+        self.assertEqual(payload, {})
+
+    def test_uses_last_json_object_after_wrapper_output(self) -> None:
+        # Arrange
+        output = 'wrapper notice\n{"result":{"pane":{"pane_id":"w5:p2"}}}\n'
+
+        # Act
+        payload = hunk_review._parse_herdr_output(output)
+
+        # Assert
+        self.assertEqual(payload["result"]["pane"]["pane_id"], "w5:p2")
+
+
+class ParseHerdrOutputErrorTest(unittest.TestCase):
+    def test_rejects_output_without_json_object(self) -> None:
+        # Arrange
+        output = "wrapper notice only\n"
+
+        # Act / Assert
+        with self.assertRaisesRegex(hunk_review.PluginError, "invalid JSON"):
+            hunk_review._parse_herdr_output(output)
+
+
+class BuildHunkArgvTest(unittest.TestCase):
+    def test_worktree_uses_continuous_watch(self) -> None:
+        # Arrange
+        repo = Path("/repo")
+        git = FakeGit({})
+
+        # Act
+        argv = hunk_review.build_hunk_argv("worktree", repo, git)
+
+        # Assert
+        self.assertEqual(
+            argv,
+            ["hunk", "diff", "--watch", "--no-transparent-bg"],
+        )
+        self.assertEqual(git.calls, [])
+
+    def test_branch_uses_upstream_merge_base_diff(self) -> None:
+        # Arrange
+        repo = Path("/repo")
+        git = FakeGit(
+            {
+                ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"): "origin/topic",
+                ("rev-parse", "--verify", "origin/topic"): "abc123",
+            }
+        )
+
+        # Act
+        argv = hunk_review.build_hunk_argv("branch", repo, git)
+
+        # Assert
+        self.assertEqual(
+            argv,
+            ["hunk", "diff", "origin/topic...HEAD", "--watch", "--no-transparent-bg"],
+        )
+
+
+class BuildHunkArgvErrorTest(unittest.TestCase):
+    def test_branch_rejects_repository_without_comparison_ref(self) -> None:
+        # Arrange
+        repo = Path("/repo")
+        git = FakeGit(
+            {
+                ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"): None,
+                ("rev-parse", "--verify", "origin/main"): None,
+            }
+        )
+
+        # Act / Assert
+        with self.assertRaisesRegex(hunk_review.PluginError, "comparison ref"):
+            hunk_review.build_hunk_argv("branch", repo, git)
+
+
+class OpenReviewTest(unittest.TestCase):
+    def test_split_opens_managed_pane_and_records_it(self) -> None:
+        # Arrange
+        context = hunk_review.ReviewContext(
+            workspace_id="w5",
+            pane_id="w5:p1",
+            cwd=Path("/repo"),
+        )
+        split_args = (
+            "pane",
+            "split",
+            "w5:p1",
+            "--direction",
+            "right",
+            "--cwd",
+            "/repo",
+            "--env",
+            "HUNK_REVIEW_MODE=worktree",
+            "--focus",
+        )
+        run_args = (
+            "pane",
+            "run",
+            "w5:p2",
+            "exec hunk diff --watch --no-transparent-bg",
+        )
+        rename_args = ("pane", "rename", "w5:p2", "hunk")
+        herdr = FakeHerdr(
+            {
+                split_args: {"result": {"pane": {"pane_id": "w5:p2"}}},
+                rename_args: {"result": {"type": "pane_renamed"}},
+                run_args: {"result": {"type": "pane_input_sent"}},
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
+
+            # Act
+            pane_id = hunk_review.open_review(
+                "worktree", "split", context, herdr, state, FakeGit({})
+            )
+
+            # Assert
+            self.assertEqual(pane_id, "w5:p2")
+            self.assertEqual(state.get("w5", "worktree", "split"), "w5:p2")
+            self.assertEqual(herdr.calls, [split_args, rename_args, run_args])
+
+    def test_existing_managed_pane_is_focused_instead_of_duplicated(self) -> None:
+        # Arrange
+        context = hunk_review.ReviewContext(
+            workspace_id="w5",
+            pane_id="w5:p1",
+            cwd=Path("/repo"),
+        )
+        herdr = FakeHerdr(
+            {
+                ("pane", "get", "w5:p2"): {
+                    "result": {"pane": {"pane_id": "w5:p2", "workspace_id": "w5"}}
+                },
+                ("plugin", "pane", "focus", "w5:p2"): {
+                    "result": {"type": "plugin_pane_focused"}
+                },
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
+            state.set("w5", "worktree", "split", "w5:p2")
+
+            # Act
+            pane_id = hunk_review.open_review(
+                "worktree", "split", context, herdr, state, FakeGit({})
+            )
+
+            # Assert
+            self.assertEqual(pane_id, "w5:p2")
+            self.assertEqual(
+                herdr.calls,
+                [
+                    ("pane", "get", "w5:p2"),
+                    ("plugin", "pane", "focus", "w5:p2"),
+                ],
+            )
+
+    def test_popup_is_not_recorded_as_a_pane(self) -> None:
+        # Arrange
+        context = hunk_review.ReviewContext(
+            workspace_id="w5",
+            pane_id="w5:p1",
+            cwd=Path("/repo"),
+        )
+        open_args = (
+            "plugin",
+            "pane",
+            "open",
+            "--plugin",
+            "hunk-review",
+            "--entrypoint",
+            "review",
+            "--placement",
+            "popup",
+            "--workspace",
+            "w5",
+            "--target-pane",
+            "w5:p1",
+            "--cwd",
+            "/repo",
+            "--env",
+            "HUNK_REVIEW_MODE=worktree",
+            "--focus",
+        )
+        herdr = FakeHerdr({open_args: {"result": {"type": "plugin_popup_opened"}}})
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
+
+            # Act
+            pane_id = hunk_review.open_review(
+                "worktree", "popup", context, herdr, state, FakeGit({})
+            )
+
+            # Assert
+            self.assertIsNone(pane_id)
+            self.assertIsNone(state.get("w5", "worktree", "popup"))
+
+    def test_missing_managed_pane_is_recreated(self) -> None:
+        # Arrange
+        context = hunk_review.ReviewContext("w5", "w5:p1", Path("/repo"))
+        split_args = (
+            "pane",
+            "split",
+            "w5:p1",
+            "--direction",
+            "right",
+            "--cwd",
+            "/repo",
+            "--env",
+            "HUNK_REVIEW_MODE=worktree",
+            "--focus",
+        )
+        run_args = (
+            "pane",
+            "run",
+            "w5:p2",
+            "exec hunk diff --watch --no-transparent-bg",
+        )
+        rename_args = ("pane", "rename", "w5:p2", "hunk")
+
+        class StalePaneHerdr(FakeHerdr):
+            def json(self, args: list[str]) -> dict:
+                if args == ["pane", "get", "w5:p9"]:
+                    self.calls.append(tuple(args))
+                    raise hunk_review.PluginError("pane not found")
+                return super().json(args)
+
+        herdr = StalePaneHerdr(
+            {
+                split_args: {"result": {"pane": {"pane_id": "w5:p2"}}},
+                rename_args: {"result": {"type": "pane_renamed"}},
+                run_args: {"result": {"type": "pane_input_sent"}},
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
+            state.set("w5", "worktree", "split", "w5:p9")
+
+            # Act
+            pane_id = hunk_review.open_review(
+                "worktree", "split", context, herdr, state, FakeGit({})
+            )
+
+            # Assert
+            self.assertEqual(pane_id, "w5:p2")
+            self.assertEqual(state.get("w5", "worktree", "split"), "w5:p2")
+
+
+class OpenReviewErrorTest(unittest.TestCase):
+    def test_unknown_mode_is_rejected_before_calling_herdr(self) -> None:
+        # Arrange
+        context = hunk_review.ReviewContext("w5", "w5:p1", Path("/repo"))
+        herdr = FakeHerdr({})
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
+
+            # Act / Assert
+            with self.assertRaisesRegex(hunk_review.PluginError, "mode"):
+                hunk_review.open_review(
+                    "shell", "split", context, herdr, state, FakeGit({})
+                )
+            self.assertEqual(herdr.calls, [])
+
+    def test_unknown_placement_is_rejected_before_calling_herdr(self) -> None:
+        # Arrange
+        context = hunk_review.ReviewContext("w5", "w5:p1", Path("/repo"))
+        herdr = FakeHerdr({})
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
+
+            # Act / Assert
+            with self.assertRaisesRegex(hunk_review.PluginError, "placement"):
+                hunk_review.open_review(
+                    "worktree", "overlay", context, herdr, state, FakeGit({})
+                )
+            self.assertEqual(herdr.calls, [])
+
+
+class ReviewContextTest(unittest.TestCase):
+    def test_plugin_context_resolves_repository_root(self) -> None:
+        # Arrange
+        git = FakeGit({("rev-parse", "--show-toplevel"): "/repo"})
+        env = {
+            "HERDR_PLUGIN_CONTEXT_JSON": (
+                '{"workspace_id":"w5","focused_pane_id":"w5:p1",'
+                '"focused_pane_cwd":"/repo/subdir"}'
+            )
+        }
+
+        # Act
+        context = hunk_review.review_context(env, git)
+
+        # Assert
+        self.assertEqual(context, hunk_review.ReviewContext("w5", "w5:p1", Path("/repo")))
+
+
+class ReviewContextErrorTest(unittest.TestCase):
+    def test_non_git_directory_is_rejected(self) -> None:
+        # Arrange
+        git = FakeGit({("rev-parse", "--show-toplevel"): None})
+        env = {
+            "HERDR_PLUGIN_CONTEXT_JSON": (
+                '{"workspace_id":"w5","focused_pane_id":"w5:p1",'
+                '"focused_pane_cwd":"/tmp"}'
+            )
+        }
+
+        # Act / Assert
+        with self.assertRaisesRegex(hunk_review.PluginError, "Git repository"):
+            hunk_review.review_context(env, git)
+
+    def test_missing_focused_pane_is_rejected(self) -> None:
+        # Arrange
+        git = FakeGit({("rev-parse", "--show-toplevel"): "/repo"})
+        env = {
+            "HERDR_PLUGIN_CONTEXT_JSON": (
+                '{"workspace_id":"w5","focused_pane_cwd":"/repo"}'
+            )
+        }
+
+        # Act / Assert
+        with self.assertRaisesRegex(hunk_review.PluginError, "pane"):
+            hunk_review.review_context(env, git)
+
+
+class PluginManifestTest(unittest.TestCase):
+    def test_manifest_exposes_all_review_modes_and_placements(self) -> None:
+        # Arrange
+        expected_commands = {
+            ("worktree-split", "worktree", "split"),
+            ("worktree-tab", "worktree", "tab"),
+            ("worktree-popup", "worktree", "popup"),
+            ("branch-split", "branch", "split"),
+            ("branch-tab", "branch", "tab"),
+            ("branch-popup", "branch", "popup"),
+        }
+
+        # Act
+        manifest = tomllib.loads((PLUGIN_DIR / "herdr-plugin.toml").read_text())
+        actual_commands = {
+            (action["id"], action["command"][3], action["command"][4])
+            for action in manifest["actions"]
+        }
+
+        # Assert
+        self.assertEqual(actual_commands, expected_commands)
+        self.assertEqual(manifest["id"], "hunk-review")
+        self.assertEqual(manifest["min_herdr_version"], "0.7.0")
+        self.assertEqual(
+            manifest["panes"],
+            [
+                {
+                    "id": "review",
+                    "title": "Hunk review",
+                    "placement": "split",
+                    "command": ["python3", "hunk_review.py", "run"],
+                }
+            ],
+        )
+
+
+class HerdrConfigTest(unittest.TestCase):
+    def test_prefix_d_opens_worktree_split_review(self) -> None:
+        # Arrange
+        config = tomllib.loads((REPO_DIR / "herdr" / "config.toml").read_text())
+
+        # Act
+        bindings = {
+            command["key"]: (command["type"], command["command"])
+            for command in config["keys"]["command"]
+        }
+
+        # Assert
+        self.assertEqual(
+            bindings["prefix+d"],
+            ("plugin_action", "hunk-review.worktree-split"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/herdr-plugins/hunk-review/hunk_review_test.py
+++ b/herdr-plugins/hunk-review/hunk_review_test.py
@@ -120,7 +120,7 @@ class BuildHunkArgvErrorTest(unittest.TestCase):
 
 
 class OpenReviewTest(unittest.TestCase):
-    def test_split_opens_managed_pane_and_records_it(self) -> None:
+    def test_split_opens_named_pane_and_runs_hunk(self) -> None:
         # Arrange
         context = hunk_review.ReviewContext(
             workspace_id="w5",
@@ -164,90 +164,44 @@ class OpenReviewTest(unittest.TestCase):
 
             # Assert
             self.assertEqual(pane_id, "w5:p2")
-            self.assertEqual(
-                state.get("w5", Path("/repo"), "worktree", "split"), "w5:p2"
-            )
             self.assertEqual(herdr.calls, [split_args, rename_args, run_args])
 
-    def test_existing_managed_pane_is_focused_instead_of_duplicated(self) -> None:
+    def test_repeated_split_opens_a_new_pane_without_plugin_focus(self) -> None:
         # Arrange
-        context = hunk_review.ReviewContext(
-            workspace_id="w5",
-            pane_id="w5:p1",
-            cwd=Path("/repo"),
-        )
-        herdr = FakeHerdr(
-            {
-                ("pane", "get", "w5:p2"): {
-                    "result": {"pane": {"pane_id": "w5:p2", "workspace_id": "w5"}}
-                },
-                ("plugin", "pane", "focus", "w5:p2"): {
-                    "result": {"type": "plugin_pane_focused"}
-                },
-            }
-        )
+        context = hunk_review.ReviewContext("w5", "w5:p1", Path("/repo"))
+
+        class RepeatedSplitHerdr:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, ...]] = []
+                self.split_count = 0
+
+            def json(self, args: list[str]) -> dict:
+                self.calls.append(tuple(args))
+                if args[:2] == ["pane", "split"]:
+                    self.split_count += 1
+                    return {
+                        "result": {"pane": {"pane_id": f"w5:p{self.split_count + 1}"}}
+                    }
+                if args[:2] in (["pane", "rename"], ["pane", "run"]):
+                    return {"result": {}}
+                raise AssertionError(f"unexpected Herdr call: {args}")
+
+        herdr = RepeatedSplitHerdr()
 
         with tempfile.TemporaryDirectory() as state_dir:
             state = hunk_review.PaneState(Path(state_dir) / "panes.json")
-            state.set("w5", Path("/repo"), "worktree", "split", "w5:p2")
 
             # Act
-            pane_id = hunk_review.open_review(
+            first_pane = hunk_review.open_review(
+                "worktree", "split", context, herdr, state, FakeGit({})
+            )
+            second_pane = hunk_review.open_review(
                 "worktree", "split", context, herdr, state, FakeGit({})
             )
 
             # Assert
-            self.assertEqual(pane_id, "w5:p2")
-            self.assertEqual(
-                herdr.calls,
-                [
-                    ("pane", "get", "w5:p2"),
-                    ("plugin", "pane", "focus", "w5:p2"),
-                ],
-            )
-
-    def test_cached_pane_from_another_repository_is_not_reused(self) -> None:
-        # Arrange
-        context = hunk_review.ReviewContext("w5", "w5:p1", Path("/repo-b"))
-        split_args = (
-            "pane",
-            "split",
-            "w5:p1",
-            "--direction",
-            "right",
-            "--cwd",
-            "/repo-b",
-            "--env",
-            "HUNK_REVIEW_MODE=worktree",
-            "--focus",
-        )
-        rename_args = ("pane", "rename", "w5:p3", "hunk")
-        run_args = (
-            "pane",
-            "run",
-            "w5:p3",
-            "exec hunk diff --watch --no-transparent-bg",
-        )
-        herdr = FakeHerdr(
-            {
-                split_args: {"result": {"pane": {"pane_id": "w5:p3"}}},
-                rename_args: {"result": {"type": "pane_renamed"}},
-                run_args: {"result": {"type": "pane_input_sent"}},
-            }
-        )
-
-        with tempfile.TemporaryDirectory() as state_dir:
-            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
-            state.set("w5", Path("/repo-a"), "worktree", "split", "w5:p2")
-
-            # Act
-            pane_id = hunk_review.open_review(
-                "worktree", "split", context, herdr, state, FakeGit({})
-            )
-
-            # Assert
-            self.assertEqual(pane_id, "w5:p3")
-            self.assertEqual(herdr.calls, [split_args, rename_args, run_args])
+            self.assertEqual((first_pane, second_pane), ("w5:p2", "w5:p3"))
+            self.assertNotIn("plugin", [call[0] for call in herdr.calls])
 
     def test_popup_is_not_recorded_as_a_pane(self) -> None:
         # Arrange
@@ -291,60 +245,6 @@ class OpenReviewTest(unittest.TestCase):
             self.assertIsNone(
                 state.get("w5", Path("/repo"), "worktree", "popup")
             )
-
-    def test_missing_managed_pane_is_recreated(self) -> None:
-        # Arrange
-        context = hunk_review.ReviewContext("w5", "w5:p1", Path("/repo"))
-        split_args = (
-            "pane",
-            "split",
-            "w5:p1",
-            "--direction",
-            "right",
-            "--cwd",
-            "/repo",
-            "--env",
-            "HUNK_REVIEW_MODE=worktree",
-            "--focus",
-        )
-        run_args = (
-            "pane",
-            "run",
-            "w5:p2",
-            "exec hunk diff --watch --no-transparent-bg",
-        )
-        rename_args = ("pane", "rename", "w5:p2", "hunk")
-
-        class StalePaneHerdr(FakeHerdr):
-            def json(self, args: list[str]) -> dict:
-                if args == ["pane", "get", "w5:p9"]:
-                    self.calls.append(tuple(args))
-                    raise hunk_review.PluginError("pane not found")
-                return super().json(args)
-
-        herdr = StalePaneHerdr(
-            {
-                split_args: {"result": {"pane": {"pane_id": "w5:p2"}}},
-                rename_args: {"result": {"type": "pane_renamed"}},
-                run_args: {"result": {"type": "pane_input_sent"}},
-            }
-        )
-
-        with tempfile.TemporaryDirectory() as state_dir:
-            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
-            state.set("w5", Path("/repo"), "worktree", "split", "w5:p9")
-
-            # Act
-            pane_id = hunk_review.open_review(
-                "worktree", "split", context, herdr, state, FakeGit({})
-            )
-
-            # Assert
-            self.assertEqual(pane_id, "w5:p2")
-            self.assertEqual(
-                state.get("w5", Path("/repo"), "worktree", "split"), "w5:p2"
-            )
-
 
 class OpenReviewErrorTest(unittest.TestCase):
     def test_unknown_mode_is_rejected_before_calling_herdr(self) -> None:

--- a/herdr-plugins/hunk-review/hunk_review_test.py
+++ b/herdr-plugins/hunk-review/hunk_review_test.py
@@ -164,7 +164,9 @@ class OpenReviewTest(unittest.TestCase):
 
             # Assert
             self.assertEqual(pane_id, "w5:p2")
-            self.assertEqual(state.get("w5", "worktree", "split"), "w5:p2")
+            self.assertEqual(
+                state.get("w5", Path("/repo"), "worktree", "split"), "w5:p2"
+            )
             self.assertEqual(herdr.calls, [split_args, rename_args, run_args])
 
     def test_existing_managed_pane_is_focused_instead_of_duplicated(self) -> None:
@@ -187,7 +189,7 @@ class OpenReviewTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as state_dir:
             state = hunk_review.PaneState(Path(state_dir) / "panes.json")
-            state.set("w5", "worktree", "split", "w5:p2")
+            state.set("w5", Path("/repo"), "worktree", "split", "w5:p2")
 
             # Act
             pane_id = hunk_review.open_review(
@@ -203,6 +205,49 @@ class OpenReviewTest(unittest.TestCase):
                     ("plugin", "pane", "focus", "w5:p2"),
                 ],
             )
+
+    def test_cached_pane_from_another_repository_is_not_reused(self) -> None:
+        # Arrange
+        context = hunk_review.ReviewContext("w5", "w5:p1", Path("/repo-b"))
+        split_args = (
+            "pane",
+            "split",
+            "w5:p1",
+            "--direction",
+            "right",
+            "--cwd",
+            "/repo-b",
+            "--env",
+            "HUNK_REVIEW_MODE=worktree",
+            "--focus",
+        )
+        rename_args = ("pane", "rename", "w5:p3", "hunk")
+        run_args = (
+            "pane",
+            "run",
+            "w5:p3",
+            "exec hunk diff --watch --no-transparent-bg",
+        )
+        herdr = FakeHerdr(
+            {
+                split_args: {"result": {"pane": {"pane_id": "w5:p3"}}},
+                rename_args: {"result": {"type": "pane_renamed"}},
+                run_args: {"result": {"type": "pane_input_sent"}},
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            state = hunk_review.PaneState(Path(state_dir) / "panes.json")
+            state.set("w5", Path("/repo-a"), "worktree", "split", "w5:p2")
+
+            # Act
+            pane_id = hunk_review.open_review(
+                "worktree", "split", context, herdr, state, FakeGit({})
+            )
+
+            # Assert
+            self.assertEqual(pane_id, "w5:p3")
+            self.assertEqual(herdr.calls, [split_args, rename_args, run_args])
 
     def test_popup_is_not_recorded_as_a_pane(self) -> None:
         # Arrange
@@ -243,7 +288,9 @@ class OpenReviewTest(unittest.TestCase):
 
             # Assert
             self.assertIsNone(pane_id)
-            self.assertIsNone(state.get("w5", "worktree", "popup"))
+            self.assertIsNone(
+                state.get("w5", Path("/repo"), "worktree", "popup")
+            )
 
     def test_missing_managed_pane_is_recreated(self) -> None:
         # Arrange
@@ -285,7 +332,7 @@ class OpenReviewTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as state_dir:
             state = hunk_review.PaneState(Path(state_dir) / "panes.json")
-            state.set("w5", "worktree", "split", "w5:p9")
+            state.set("w5", Path("/repo"), "worktree", "split", "w5:p9")
 
             # Act
             pane_id = hunk_review.open_review(
@@ -294,7 +341,9 @@ class OpenReviewTest(unittest.TestCase):
 
             # Assert
             self.assertEqual(pane_id, "w5:p2")
-            self.assertEqual(state.get("w5", "worktree", "split"), "w5:p2")
+            self.assertEqual(
+                state.get("w5", Path("/repo"), "worktree", "split"), "w5:p2"
+            )
 
 
 class OpenReviewErrorTest(unittest.TestCase):

--- a/herdr/.gitignore
+++ b/herdr/.gitignore
@@ -1,2 +1,4 @@
 herdr*.log
 session*.json
+plugins.json
+plugins/

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -91,6 +91,12 @@ type = "pane"
 command = "zsh -ic herdr-ghq-workspace"
 description = "open ghq project as workspace"
 
+[[keys.command]]
+key = "prefix+d"
+type = "plugin_action"
+command = "hunk-review.worktree-split"
+description = "open or focus Hunk worktree review"
+
 [experimental]
 reveal_hidden_cursor_for_cjk_ime = true
 cjk_ime_agents = ["pi", "claude", "codex"]

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -95,7 +95,7 @@ description = "open ghq project as workspace"
 key = "prefix+d"
 type = "plugin_action"
 command = "hunk-review.worktree-split"
-description = "open or focus Hunk worktree review"
+description = "open Hunk worktree review"
 
 [experimental]
 reveal_hidden_cursor_for_cjk_ime = true

--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -30,6 +30,7 @@
         config
         dotfilesDir
         helpers
+        herdrPackage
         ;
     })
   ];

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -111,17 +111,18 @@ in
     if [ -z "''${DRY_RUN_CMD:-}" ]; then
       plugin_path="${dotfilesDir}/herdr-plugins/hunk-review"
       plugin_manifest="$plugin_path/herdr-plugin.toml"
-      plugin_json="$(${herdrPackage}/bin/herdr plugin list --plugin hunk-review --json 2>/dev/null || true)"
-      registered_manifest="$(printf '%s\n' "$plugin_json" \
-        | ${pkgs.jq}/bin/jq -r '.result.plugins[]? | select(.plugin_id == "hunk-review") | .manifest_path')"
-      registered_enabled="$(printf '%s\n' "$plugin_json" \
-        | ${pkgs.jq}/bin/jq -r '.result.plugins[]? | select(.plugin_id == "hunk-review") | .enabled')"
+      if plugin_json="$(${herdrPackage}/bin/herdr plugin list --plugin hunk-review --json 2>/dev/null)"; then
+        registered_manifest="$(printf '%s\n' "$plugin_json" \
+          | ${pkgs.jq}/bin/jq -r '.result.plugins[]? | select(.plugin_id == "hunk-review") | .manifest_path')"
+        registered_enabled="$(printf '%s\n' "$plugin_json" \
+          | ${pkgs.jq}/bin/jq -r '.result.plugins[]? | select(.plugin_id == "hunk-review") | .enabled')"
 
-      if [ "$registered_manifest" != "$plugin_manifest" ]; then
-        if [ "$registered_enabled" = "false" ]; then
-          ${herdrPackage}/bin/herdr plugin link "$plugin_path" --disabled
-        else
-          ${herdrPackage}/bin/herdr plugin link "$plugin_path"
+        if [ "$registered_manifest" != "$plugin_manifest" ]; then
+          if [ "$registered_enabled" = "false" ]; then
+            ${herdrPackage}/bin/herdr plugin link "$plugin_path" --disabled
+          else
+            ${herdrPackage}/bin/herdr plugin link "$plugin_path"
+          fi
         fi
       fi
     fi

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -4,6 +4,7 @@
   config,
   dotfilesDir,
   helpers,
+  herdrPackage,
   ...
 }:
 let
@@ -104,5 +105,25 @@ in
     $DRY_RUN_CMD mkdir -p "${configHome}/git"
     link_force "${dotfilesDir}/git/ignore" "${configHome}/git/ignore"
     link_force "${dotfilesDir}/git/hooks" "${configHome}/git/hooks"
+  '';
+
+  home.activation.linkHerdrPlugins = lib.hm.dag.entryAfter [ "linkDotfiles" ] ''
+    if [ -z "''${DRY_RUN_CMD:-}" ]; then
+      plugin_path="${dotfilesDir}/herdr-plugins/hunk-review"
+      plugin_manifest="$plugin_path/herdr-plugin.toml"
+      plugin_json="$(${herdrPackage}/bin/herdr plugin list --plugin hunk-review --json 2>/dev/null || true)"
+      registered_manifest="$(printf '%s\n' "$plugin_json" \
+        | ${pkgs.jq}/bin/jq -r '.result.plugins[]? | select(.plugin_id == "hunk-review") | .manifest_path')"
+      registered_enabled="$(printf '%s\n' "$plugin_json" \
+        | ${pkgs.jq}/bin/jq -r '.result.plugins[]? | select(.plugin_id == "hunk-review") | .enabled')"
+
+      if [ "$registered_manifest" != "$plugin_manifest" ]; then
+        if [ "$registered_enabled" = "false" ]; then
+          ${herdrPackage}/bin/herdr plugin link "$plugin_path" --disabled
+        else
+          ${herdrPackage}/bin/herdr plugin link "$plugin_path"
+        fi
+      fi
+    fi
   '';
 }

--- a/nono/profiles/chouge-agent-common.json
+++ b/nono/profiles/chouge-agent-common.json
@@ -42,6 +42,15 @@
     }
   },
   "command_policies": {
+    "approval_backends": {
+      "terminal": {
+        "type": "terminal"
+      }
+    },
+    "approval_defaults": {
+      "backend": "terminal",
+      "timeout_secs": 60
+    },
     "commands": {
       "container": {
         "executable": "/opt/homebrew/opt/container/libexec/container",
@@ -70,7 +79,7 @@
               ]
             },
             "invocation_policy": {
-              "default": "allow",
+              "default": "approve",
               "deny": [
                 {
                   "argv": { "prefix": ["registry", "login"] },
@@ -92,6 +101,30 @@
                   "argv": { "prefix": ["system", "kernel", "set"] },
                   "reason": "system kernel changes are not delegated to agents"
                 }
+              ],
+              "allow": [
+                { "argv": { "exact": [] } },
+                { "argv": { "exact": ["--help"] } },
+                { "argv": { "exact": ["--version"] } },
+                { "argv": { "prefix": ["list"] } },
+                { "argv": { "prefix": ["inspect"] } },
+                { "argv": { "prefix": ["logs"] } },
+                { "argv": { "prefix": ["stats"] } },
+                { "argv": { "prefix": ["builder", "status"] } },
+                { "argv": { "prefix": ["image", "list"] } },
+                { "argv": { "prefix": ["image", "inspect"] } },
+                { "argv": { "prefix": ["registry", "list"] } },
+                { "argv": { "prefix": ["network", "list"] } },
+                { "argv": { "prefix": ["network", "inspect"] } },
+                { "argv": { "prefix": ["volume", "list"] } },
+                { "argv": { "prefix": ["volume", "inspect"] } },
+                { "argv": { "prefix": ["machine", "list"] } },
+                { "argv": { "prefix": ["machine", "inspect"] } },
+                { "argv": { "prefix": ["machine", "logs"] } },
+                { "argv": { "prefix": ["system", "version"] } },
+                { "argv": { "prefix": ["system", "df"] } },
+                { "argv": { "prefix": ["system", "property", "list"] } },
+                { "argv": { "prefix": ["system", "dns", "list"] } }
               ]
             }
           }

--- a/nono/profiles/chouge-agent-common.json
+++ b/nono/profiles/chouge-agent-common.json
@@ -23,7 +23,11 @@
       "$HOME/.claude.lock"
     ],
     "read": [
-      "$HOME/.local/share/nono-agent-wrappers"
+      "$HOME/.local/share/nono-agent-wrappers",
+      "$HOME/ghq/github.com/nananaman/dotfiles/apm"
+    ],
+    "unix_socket": [
+      "$HOME/.config/herdr/herdr.sock"
     ]
   },
   "platform_overrides": {
@@ -38,15 +42,6 @@
     }
   },
   "command_policies": {
-    "approval_backends": {
-      "terminal": {
-        "type": "terminal"
-      }
-    },
-    "approval_defaults": {
-      "backend": "terminal",
-      "timeout_secs": 60
-    },
     "commands": {
       "container": {
         "executable": "/opt/homebrew/opt/container/libexec/container",
@@ -75,7 +70,7 @@
               ]
             },
             "invocation_policy": {
-              "default": "approve",
+              "default": "allow",
               "deny": [
                 {
                   "argv": { "prefix": ["registry", "login"] },
@@ -97,30 +92,6 @@
                   "argv": { "prefix": ["system", "kernel", "set"] },
                   "reason": "system kernel changes are not delegated to agents"
                 }
-              ],
-              "allow": [
-                { "argv": { "exact": [] } },
-                { "argv": { "exact": ["--help"] } },
-                { "argv": { "exact": ["--version"] } },
-                { "argv": { "prefix": ["list"] } },
-                { "argv": { "prefix": ["inspect"] } },
-                { "argv": { "prefix": ["logs"] } },
-                { "argv": { "prefix": ["stats"] } },
-                { "argv": { "prefix": ["builder", "status"] } },
-                { "argv": { "prefix": ["image", "list"] } },
-                { "argv": { "prefix": ["image", "inspect"] } },
-                { "argv": { "prefix": ["registry", "list"] } },
-                { "argv": { "prefix": ["network", "list"] } },
-                { "argv": { "prefix": ["network", "inspect"] } },
-                { "argv": { "prefix": ["volume", "list"] } },
-                { "argv": { "prefix": ["volume", "inspect"] } },
-                { "argv": { "prefix": ["machine", "list"] } },
-                { "argv": { "prefix": ["machine", "inspect"] } },
-                { "argv": { "prefix": ["machine", "logs"] } },
-                { "argv": { "prefix": ["system", "version"] } },
-                { "argv": { "prefix": ["system", "df"] } },
-                { "argv": { "prefix": ["system", "property", "list"] } },
-                { "argv": { "prefix": ["system", "dns", "list"] } }
               ]
             }
           }


### PR DESCRIPTION
## 概要

- `prefix+d` から現在の Git repository の Hunk review を右 split で開く local Herdr plugin を追加
- Hunk を `--watch` 付きで起動し、shell を `exec hunk` で置換
- Home Manager activation で plugin を登録し、既存の enabled / disabled 状態を維持
- agent sandbox に APM source の read access と Herdr socket access を追加
- repository 移転後の `nananaman/dotfiles` path へ参照を更新
- 旧 `hunk-human-review` skill dependency を削除

## 設計上の注意

- Herdr 0.7.4 では raw split pane を ID 指定で再 focus できないため、`prefix+d` の split は毎回新規作成する
- Herdr server 不在時は Home Manager activation を失敗させず、plugin 登録を次回 activation まで延期する
- Hunk の user comment は live session 内にあるため、TUI を閉じる前に agent が回収する

## 検証

- `python3 -m unittest hunk_review_test.py`（16 tests）
- `python3 -m py_compile hunk_review.py hunk_review_test.py`
- `herdr config check`
- `nono profile validate --strict`（全4 profiles、既知の Seatbelt warning のみ）
- `nono why` で container policy の allow / approve / deny 境界を確認
- `nix run .#build`
- `git diff --check`
- autoreview: clean（accepted/actionable findings なし）
