### PR TITLE
chore(agent): 外部プラグイン設定を削除する

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -32,25 +32,6 @@
       }
     ]
   },
-  "enabledPlugins": {
-    "code-simplifier@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true,
-    "feature-dev@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true,
-    "hookify@claude-plugins-official": true,
-    "gopls-lsp@claude-plugins-official": true,
-    "superpowers@superpowers-marketplace": true,
-    "superpowers-developing-for-claude-code@superpowers-marketplace": true,
-    "nono@nolabs-ai": true
-  },
-  "extraKnownMarketplaces": {
-    "superpowers-marketplace": {
-      "source": {
-        "source": "github",
-        "repo": "obra/superpowers-marketplace"
-      }
-    }
-  },
   "language": "Japanese",
   "alwaysThinkingEnabled": true,
   "theme": "dark",


### PR DESCRIPTION
## Summary
- Agent skillの管理経路をAPMへ集約し、Claude Code固有の外部plugin設定を削除します。

## Changes
- Claude Codeの`enabledPlugins`を削除
- Superpowers marketplace設定を削除
- OpenAI/Codex組み込みskillとAPM管理skillには影響なし

## Tests
- `python3 -m json.tool claude/settings.json`
- `git diff --check`

## Review notes
- 対象base: `origin/main`
- `review-diff-code`は実行環境の問題で完了できず、ユーザー判断により今回は保留
  - Pi: nonoによる`spawn EPERM`およびnpm cache権限エラー
  - Codex: reviewer隔離に必要な`bwrap`がmacOS環境に存在しない
- 差分は`claude/settings.json`から外部plugin設定19行を削除する1ファイルのみ
