### PR TITLE
fix(pi): レビュー用sandbox構成を安定化する

### DIFF
--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -56,8 +56,6 @@ in
     link_force "${agentCommonProfile}" "${configHome}/nono/profiles/chouge-agent-common.json"
     link_force "${dotfilesDir}/nono/profiles/chouge-codex.json" "${configHome}/nono/profiles/chouge-codex.json"
     link_force "${dotfilesDir}/nono/profiles/chouge-claude.json" "${configHome}/nono/profiles/chouge-claude.json"
-    link_force "${dotfilesDir}/nono/profiles/chouge-pi.json" "${configHome}/nono/profiles/chouge-pi.json"
-
     link_force "${dotfilesDir}/apm" "${homeDirectory}/.apm"
 
     ${lib.optionalString pkgs.stdenv.isLinux ''

--- a/nix/modules/home/programs/default.nix
+++ b/nix/modules/home/programs/default.nix
@@ -12,6 +12,6 @@
     (import ./hunk.nix { inherit pkgs hunkInput; })
     ./starship.nix
     (import ./claude-code.nix { inherit config dotfilesDir; })
-    (import ./pi.nix { inherit config dotfilesDir; })
+    (import ./pi.nix { inherit pkgs config dotfilesDir; })
   ];
 }

--- a/nix/modules/home/programs/pi.nix
+++ b/nix/modules/home/programs/pi.nix
@@ -1,17 +1,43 @@
-{ config, dotfilesDir, ... }:
+{
+  pkgs,
+  config,
+  dotfilesDir,
+  ...
+}:
 let
   piAgentDir = "${dotfilesDir}/pi/agent";
+  packageManager = "${pkgs.bun}/bin/bun";
+  settings = builtins.fromJSON (builtins.readFile ../../../../pi/agent/settings.json) // {
+    npmCommand = [ packageManager ];
+  };
+  baseProfile = builtins.fromJSON (builtins.readFile ../../../../nono/profiles/chouge-pi.json);
+  platformOverrides = baseProfile.platform_overrides or { };
+  macos = platformOverrides.macos or { };
+  seatbeltRules = macos.unsafe_macos_seatbelt_rules or [ ];
+  profile = baseProfile // {
+    platform_overrides = platformOverrides // {
+      macos = macos // {
+        unsafe_macos_seatbelt_rules = seatbeltRules ++ [
+          ''(allow process-exec (literal "${packageManager}"))''
+        ];
+      };
+    };
+  };
 in
 {
   home.file = {
-    ".pi/agent/settings.json".source =
-      config.lib.file.mkOutOfStoreSymlink "${piAgentDir}/settings.json";
+    ".pi/agent/settings.json" = {
+      text = builtins.toJSON settings;
+      force = true;
+    };
+    ".config/nono/profiles/chouge-pi.json" = {
+      text = builtins.toJSON profile;
+      force = true;
+    };
     ".pi/agent/pi-codex-conversion.json" = {
       source = config.lib.file.mkOutOfStoreSymlink "${piAgentDir}/pi-codex-conversion.json";
       force = true;
     };
-    ".pi/agent/extensions/rtk.ts".source =
-      config.lib.file.mkOutOfStoreSymlink "${piAgentDir}/extensions/rtk.ts";
     ".pi/agent/extensions/tirith-guard.ts".source =
       config.lib.file.mkOutOfStoreSymlink "${piAgentDir}/extensions/tirith-guard.ts";
     ".pi/agent/extensions/herdr-agent-state.ts" = {

--- a/nono/profiles/chouge-agent-common.json
+++ b/nono/profiles/chouge-agent-common.json
@@ -24,6 +24,9 @@
       "$HOME/.claude.json.lock",
       "$HOME/.claude.lock"
     ],
+    "bypass_protection": [
+      "$HOME/ghq/github.com/nananaman/dotfiles/zsh/zshrc"
+    ],
     "read": [
       "$HOME/.local/share/nono-agent-wrappers",
       "$HOME/ghq/github.com/nananaman/dotfiles/apm"

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -3,13 +3,9 @@
   "defaultModel": "gpt-5.5",
   "defaultThinkingLevel": "high",
   "packages": [
-    "npm:pi-web-access",
-    "npm:@tintinweb/pi-subagents@0.10.3",
-    "npm:@juicesharp/rpiv-ask-user-question@1.20.0",
-    "npm:@howaboua/pi-codex-conversion",
-    "npm:pi-mcp-extension@1.5.0",
+    "npm:@howaboua/pi-codex-conversion@2.2.16",
     {
-      "source": "/Users/juntawatanabe/.config/nono/packages/nolabs-ai/pi"
+      "source": "~/.config/nono/packages/nolabs-ai/pi"
     }
   ],
   "lastChangelogVersion": "0.80.3",


### PR DESCRIPTION
## Summary

- Piのnpm package managerをNixでpinしたBunへ固定する
- Piをレビュー用途に必要な最小package構成へ整理する
- nono sandbox内でPi起動とNix buildが失敗する権限境界を修正する

## Changes

- Pi settingsと`chouge-pi` profileをHome Managerで同じBun store pathから生成
- 既存のmacOS Seatbelt ruleを保持しつつ、pinしたBunのchild process実行だけを許可
- Pi settings/profileの既存symlinkから生成ファイルへの移行を`force`付きで管理
- web access、subagent、ask-user、MCP、RTK extensionを外し、Codex conversionとnono連携に限定
- dotfiles管理元の`zsh/zshrc`だけをshell config保護の例外にし、sandbox内のNix buildを許可

## Tests

- `nixfmt --check nix/modules/home/programs/pi.nix`
- `git diff --check`
- `nix run .#build`
- `nix run .#switch`（ユーザー環境で成功）
- `pi`（ユーザー環境で起動成功）
- `nono profile validate --strict nono/profiles/chouge-agent-common.json`
- `nono profile validate --strict nono/profiles/chouge-codex.json`
- `nono why`で管理元`zsh/zshrc`がallow、無関係な`~/.zprofile`がdenyであることを確認

## Review notes

- `review-diff-code.py --mode branch --base origin/main`
- engine: Pi、3 reviewer、bundle-only isolation
- 初回findingの既存Seatbelt rule上書きを修正
- 修正後の再reviewは3 reviewerすべて成功、actionable findingなし
- その後のlocal package path portable化は`nix run .#build`で検証。review runner不調のため、ユーザー合意のうえ追加reviewは省略
- PR templateなし
