### PR TITLE
docs(agents): agent指示を判断可能な契約に整理する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,57 +1,38 @@
-# AGENTS.md
+# Repository instructions
 
-This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+macOS aarch64 環境の dotfiles を、Nix Flakes、nix-darwin、home-manager で管理する repository。
 
-## Overview
+## 設計
 
-macOS (aarch64-darwin) dotfiles managed by Nix Flakes + nix-darwin + home-manager.
+- `flake.nix` を Nix 構成のエントリポイントとする。
+- macOS のシステム設定は nix-darwin、ユーザー環境は home-manager で管理する。
+- dotfile 本体は Nix で生成せず、この repository から out-of-store symlink する。
+- package の導入と symlink の作成は Nix module で管理する。
+- グローバル agent 指示は `agents/AGENTS.md` を source of truth とする。
+- グローバル agent skill の依存一覧は `apm/apm.yml` を source of truth とする。
 
-## Commands
+## 検証と適用
+
+Nix の変更後は、対象ファイルを `nixfmt` で整形し、次を実行する。
 
 ```bash
-# ドライビルド
 nix run .#build
-
-# ビルド＆適用（sudo必要）
-nix run .#switch
-
-# flake.lock 更新
-nix run .#update
-
-# APM user-scope agent skills を展開
-apm install -g
 ```
 
-## Architecture
+Neovim の Lua ファイルは `stylua` で整形する。
 
-**flake.nix** がエントリポイント。`darwinConfigurations` で nix-darwin + home-manager を組み合わせている。
+システムへの適用は、ユーザーが明示的に依頼した場合にのみ実行する。
 
-### Nix モジュール構成
+```bash
+nix run .#switch
+```
 
-- `nix/modules/darwin/system.nix` — macOS システム設定（Dock, Finder, キーボード）、Homebrew casks
-- `nix/modules/home/` — home-manager モジュール群
-  - `packages.nix` — CLI ツール一覧（zsh, fzf, ripgrep, neovim, apm-cli 等）
-  - `dotfiles.nix` — `home.activation` でシンボリックリンクを作成（nvim, zsh, ghostty 等をこのリポジトリから直接リンク）
-  - `programs/` — home-manager の `programs.*` を使うアプリ設定（git, starship, Codex, codex）
-- `nix/modules/lib/helpers/` — activation 用のユーティリティ関数
-- `nix/overlays/` — カスタムパッケージオーバーレイ（現在は空）
+その他の操作:
 
-### dotfiles の管理方式
+```bash
+# flake.lock を更新
+nix run .#update
 
-設定ファイルは Nix で生成するのではなく、このリポジトリに直接置いて `dotfiles.nix` の `link_force` でシンボリックリンクしている。Nix が管理するのはパッケージインストールとリンク作成のみ。
-
-### Global Agent Instructions
-
-グローバル agent 指示は `agents/AGENTS.md` を唯一の source of truth として管理する。home-manager が同じファイルを `~/.claude/CLAUDE.md`, `~/.config/codex/instructions.md`, `~/.pi/agent/AGENTS.md` にリンクする。
-
-### Agent Skills
-
-グローバル agent skills のインストール一覧は `apm/apm.yml` で管理する。自作汎用 skill 本体は `nananaman/skills` を source-of-truth にし、dotfiles 側から full SHA で pin して参照する。`dotfiles.nix` が `apm/` を `~/.apm` にリンクし、`apm install -g` が `target: claude,agent-skills` に従って `~/.claude/skills` と `~/.agents/skills` に展開する。`apm.lock.yaml` と `apm_modules/` は `apm/.gitignore` で除外するため、外部 dependency は full SHA で pin する。
-
-### Nix フォーマット
-
-Nix ファイルは `nixfmt` (RFC style) でフォーマットする。
-
-### Lua フォーマット
-
-`stylua.toml` でフォーマット設定済み。Neovim の Lua ファイルは `stylua` を使う。
+# APM user-scope skills を展開
+apm install -g
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # Repository instructions
 
-macOS aarch64 環境の dotfiles を、Nix Flakes、nix-darwin、home-manager で管理する repository。
+macOS（aarch64-darwin）と WSL（x86_64-linux）の dotfiles を、Nix Flakes、nix-darwin、home-manager で管理する repository。
 
 ## 設計
 
 - `flake.nix` を Nix 構成のエントリポイントとする。
-- macOS のシステム設定は nix-darwin、ユーザー環境は home-manager で管理する。
+- macOS のシステム設定は nix-darwin、macOS と WSL のユーザー環境は home-manager で管理する。
 - dotfile 本体は Nix で生成せず、この repository から out-of-store symlink する。
 - package の導入と symlink の作成は Nix module で管理する。
 - グローバル agent 指示は `agents/AGENTS.md` を source of truth とする。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,57 +1,38 @@
-# CLAUDE.md
+# Repository instructions
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+macOS aarch64 環境の dotfiles を、Nix Flakes、nix-darwin、home-manager で管理する repository。
 
-## Overview
+## 設計
 
-macOS (aarch64-darwin) dotfiles managed by Nix Flakes + nix-darwin + home-manager.
+- `flake.nix` を Nix 構成のエントリポイントとする。
+- macOS のシステム設定は nix-darwin、ユーザー環境は home-manager で管理する。
+- dotfile 本体は Nix で生成せず、この repository から out-of-store symlink する。
+- package の導入と symlink の作成は Nix module で管理する。
+- グローバル agent 指示は `agents/AGENTS.md` を source of truth とする。
+- グローバル agent skill の依存一覧は `apm/apm.yml` を source of truth とする。
 
-## Commands
+## 検証と適用
+
+Nix の変更後は、対象ファイルを `nixfmt` で整形し、次を実行する。
 
 ```bash
-# ドライビルド
 nix run .#build
-
-# ビルド＆適用（sudo必要）
-nix run .#switch
-
-# flake.lock 更新
-nix run .#update
-
-# APM user-scope agent skills を展開
-apm install -g
 ```
 
-## Architecture
+Neovim の Lua ファイルは `stylua` で整形する。
 
-**flake.nix** がエントリポイント。`darwinConfigurations` で nix-darwin + home-manager を組み合わせている。
+システムへの適用は、ユーザーが明示的に依頼した場合にのみ実行する。
 
-### Nix モジュール構成
+```bash
+nix run .#switch
+```
 
-- `nix/modules/darwin/system.nix` — macOS システム設定（Dock, Finder, キーボード）、Homebrew casks
-- `nix/modules/home/` — home-manager モジュール群
-  - `packages.nix` — CLI ツール一覧（zsh, fzf, ripgrep, neovim, apm-cli 等）
-  - `dotfiles.nix` — `home.activation` でシンボリックリンクを作成（nvim, zsh, ghostty 等をこのリポジトリから直接リンク）
-  - `programs/` — home-manager の `programs.*` を使うアプリ設定（git, starship, claude-code, codex）
-- `nix/modules/lib/helpers/` — activation 用のユーティリティ関数
-- `nix/overlays/` — カスタムパッケージオーバーレイ（現在は空）
+その他の操作:
 
-### dotfiles の管理方式
+```bash
+# flake.lock を更新
+nix run .#update
 
-設定ファイルは Nix で生成するのではなく、このリポジトリに直接置いて `dotfiles.nix` の `link_force` でシンボリックリンクしている。Nix が管理するのはパッケージインストールとリンク作成のみ。
-
-### Global Agent Instructions
-
-グローバル agent 指示は `agents/AGENTS.md` を唯一の source of truth として管理する。home-manager が同じファイルを `~/.claude/CLAUDE.md`, `~/.config/codex/instructions.md`, `~/.pi/agent/AGENTS.md` にリンクする。
-
-### Agent Skills
-
-グローバル agent skills は `apm/apm.yml` で管理する。`dotfiles.nix` が `apm/` を `~/.apm` にリンクし、`apm install -g` が `target: claude,agent-skills` に従って `~/.claude/skills` と `~/.agents/skills` に展開する。`apm.lock.yaml` と `apm_modules/` は `apm/.gitignore` で除外するため、外部 dependency は full SHA で pin する。
-
-### Nix フォーマット
-
-Nix ファイルは `nixfmt` (RFC style) でフォーマットする。
-
-### Lua フォーマット
-
-`stylua.toml` でフォーマット設定済み。Neovim の Lua ファイルは `stylua` を使う。
+# APM user-scope skills を展開
+apm install -g
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
 # Repository instructions
 
-macOS aarch64 環境の dotfiles を、Nix Flakes、nix-darwin、home-manager で管理する repository。
+macOS（aarch64-darwin）と WSL（x86_64-linux）の dotfiles を、Nix Flakes、nix-darwin、home-manager で管理する repository。
 
 ## 設計
 
 - `flake.nix` を Nix 構成のエントリポイントとする。
-- macOS のシステム設定は nix-darwin、ユーザー環境は home-manager で管理する。
+- macOS のシステム設定は nix-darwin、macOS と WSL のユーザー環境は home-manager で管理する。
 - dotfile 本体は Nix で生成せず、この repository から out-of-store symlink する。
 - package の導入と symlink の作成は Nix module で管理する。
 - グローバル agent 指示は `agents/AGENTS.md` を source of truth とする。

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,43 +1,30 @@
 # グローバル Agent 指示
 
 ## コミュニケーション
-- 常に日本語で対話する
-- Always respond in Japanese, even when the prompt, tool output, or reviewed content is written in English.
-- PR title / body / reviewer 向け説明は、ユーザーから別指定がない限り日本語で書く
-- Write PR titles, PR descriptions, and reviewer-facing explanations in Japanese unless the user explicitly asks for another language.
-- 不明瞭な指示は質問して明確にする
-- ユーザーが設計・方針について質問している段階では変更承認と解釈せず、選択肢と推奨案を説明して方向性の合意を待ってから着手する（理由: 問いかけへの即時修正は、未合意の設計を既成事実にして手戻りを増やす）
-- project の `AGENTS.md` や `CLAUDE.md` がある場合は、その追加指示も尊重する
 
-## 開発スタイル
-- TDD で開発する（探索 → Red → Green → Refactoring）
-- KPI やカバレッジ目標が与えられたら、達成するまで試行する
-- コード・設定変更では、完了報告前に該当 review gate（通常は `review-diff-code`）を通し、採用指摘を修正して再確認する（理由: test だけでは設計・運用・security regression を拾い切れない）
+- ユーザーとの対話、PR title・body、reviewer 向け説明は、別指定がない限り日本語で書く。
+- 設計や方針についての質問は変更承認と解釈しない。選択肢と推奨案を示し、方向性の合意後に変更する。
+- 結果や変更範囲を大きく左右する不明点は確認する。それ以外は、安全な仮定を明示して進める。
 
-## コード設計
-- 関心の分離を保つ
-- 状態とロジックを分離する
-- 可読性と保守性を重視する
-- コントラクト層（API/型）を厳密に定義し、実装層は再生成可能に保つ
-- 静的検査可能なルールはプロンプトではなく、その環境の linter で記述する
-- コメントは必要な箇所にのみ付け、自明なことは書かない
+## 開発と検証
 
-## TODO / 後続タスク
-- 意図的に未完了・暫定・後続タスク依存の実装を残す場合は、先に追跡 issue / task を用意し、コード内 TODO に `TODO: <issue/task link> <何をいつ実装/削除/置換するか>` を書く（理由: レビュー時と後日の見返しで、未完了状態の意図と回収先を追えるようにする）
+- 実行可能な振る舞いを変更するときは `tdd` skill に従う。
+- テストを追加・変更・レビューするときは `test-writing-style` skill に従う。
+- KPI やカバレッジ目標が指定された場合は、達成するまで検証と改善を続ける。
+- コード、設定、テスト、schema、依存関係、agent 指示を変更した場合は、完了報告前に `review-diff-code` で累積差分を確認する。
+- 差分全体が、振る舞いと契約に影響しないコメント、誤字、空白、formatter のみの変更であることを確認できる場合は、review を省略してよい。
+- review やその他の検証を実行できなかった場合は、未検証事項と残るリスクを報告する。
 
-## テスト
-- テストを新規追加・修正・レビューするときは `test-writing-style` skill を使う
+## 実装上の契約
 
-## 環境
-- GitHub: {{ .github_username }}
-- リポジトリ: ghq 管理（`~/ghq/github.com/owner/repo`）
+- 公開 API、型、設定 schema など、利用側との境界を明確に定義する。
+- 静的に検査できる規則は、agent 指示ではなく、その環境の linter や formatter に実装する。
+- 意図的な未完了実装や暫定対応を残す場合は、追跡 issue または task を先に用意する。
+- コード内 TODO には、追跡先と、何をいつ実装・削除・置換するかを書く。
 
-## スキル作成・改善
-新規 skill の配置先は次の指針で決める:
+## Workflows
 
-- **project 固有**（`<repo>/.claude/skills/`）: 特定 repo のドメイン知識・規約・ファイルレイアウトに依存し、他 repo で使う見込みがない
-- **グローバル**: APM user scope で管理する。外部由来・自作汎用 skill は `apm/apm.yml` に full SHA で pin し、`apm install -g` で `~/.claude/skills/` と `~/.agents/skills/` に展開する
-- **自作汎用 skill**: `nananaman/skills` を source-of-truth として追加し、dotfiles の `apm/apm.yml` から `nananaman/skills/<path>#<full-sha>` で参照する
-- **判断不能なとき**: 「project 固有かグローバルか」を質問してから作成
-
-現在のグローバル skill は `apm/apm.yml` を唯一の source of truth として管理する。APM 0.14.2 の user scope では `targets:` ではなく `target: claude,agent-skills` を使う。`apm.lock.yaml` と `apm_modules/` は `apm/.gitignore` で除外する。`gogcli` は未使用のため廃止済み。
+- Git 操作では `chouge-git` skill に従う。
+- `CHANGES.md` の変更履歴では `chouge-changelog` skill に従う。
+- agent skill の作成・改善では `skill-workbench` skill に従う。
+- APM の設定や運用では `apm-usage` skill に従う。


### PR DESCRIPTION
## Summary

- グローバル agent 指示を、判断可能な契約と skill routing に整理する
- dotfiles 固有の `AGENTS.md` / `CLAUDE.md` を、設計判断と検証・適用方法に絞る

## Changes

- 日本語指定の重複、一般的な設計標語、未展開 placeholder、古い APM 実装情報を削除
- TDD、テスト記述、Git、changelog、skill、APM の詳細を対応する skill へ委譲
- コード・設定・テスト・schema・依存関係・agent 指示の変更に closeout review を要求
- 振る舞いと契約に影響しないコメント、誤字、空白、formatter のみを review 省略対象として定義
- `nix run .#switch` は明示依頼時のみ実行する authority boundary を追加

## Tests

- `git diff --check origin/main...HEAD`
- `AGENTS.md` と `CLAUDE.md` の内容一致を `cmp` で確認

## Review notes

- `review-diff-code --mode local` を pi / Codex / Claude engine で試行
- helper 環境の不具合により Context Builder が完了せず、3 reviewer の review は未完了
- `review-diff-code` の修正は別 repository の専用 Codex agent に委譲済み
- 今回の branch は `origin/main` から作成し、対象3ファイル以外の既存作業を含まない
