### PR TITLE
docs(agents): Nix設定変更の注意点を固定する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ apm install -g
 
 設定ファイルは Nix で生成するのではなく、このリポジトリに直接置いて `dotfiles.nix` の `link_force` でシンボリックリンクしている。Nix が管理するのはパッケージインストールとリンク作成のみ。
 
+### Nix / Home Manager の変更規則
+
+- Flake から新規ファイルを参照するときは、Git の追跡対象と確認できるまで build 検証へ進まない（理由: Git source の Flake は未追跡ファイルを入力に含めない）。
+- activation や手動配置から `home.file` へ管理を移すときは、既存 target を確認し、`force`、backup、または削除の方針を決めてから switch する（理由: build 成功後の activation で clobber が発覚するため）。
+- 配布する dotfile には literal な home directory を書かず、consumer が対応する `~`、`$HOME`、または Home Manager の値を使う（理由: username と配置場所への不要な依存を防ぐため）。
+
 ### Global Agent Instructions
 
 グローバル agent 指示は `agents/AGENTS.md` を唯一の source of truth として管理する。home-manager が同じファイルを `~/.claude/CLAUDE.md`, `~/.config/codex/instructions.md`, `~/.pi/agent/AGENTS.md` にリンクする。


### PR DESCRIPTION
## Summary

- Pi / nono対応のretrospectiveから、Nix設定変更で再発しやすい3つの注意点をproject instructionsへ固定する

## Changes

- Flakeが参照する新規ファイルのGit追跡確認を要求
- activation・手動配置から`home.file`へ移行するときの衝突方針を要求
- 配布dotfileでliteralなhome directoryを避ける規則を追加

## Tests

- `git diff --check`

## Review notes

- `retrospective-codify`で再利用性・重複・配置先を確認
- `improve-agent-prompt`で完了条件、理由、曖昧さをstatic contract review
- `review-diff-code`はrunner不調のため、ユーザー合意により省略
- PR templateなし
