### PR TITLE
docs(agents): 変更前のbranch確認を必須にする

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -8,6 +8,7 @@
 
 ## 開発と検証
 
+- ファイルを変更する前に、現在の branch と working tree を確認し、default branch や別目的の branch に変更を混ぜない。（理由: commit や PR の分離が困難になるのを防ぐ）
 - 実行可能な振る舞いを変更するときは `tdd` skill に従う。
 - テストを追加・変更・レビューするときは `test-writing-style` skill に従う。
 - KPI やカバレッジ目標が指定された場合は、達成するまで検証と改善を続ける。


### PR DESCRIPTION
## Summary

- ファイル変更前の branch / working tree 確認をグローバル agent 指示に追加する
- default branch や別目的の branch への変更混入を防ぐ

## Changes

- `agents/AGENTS.md` の「開発と検証」に、変更開始前の preflight contract を追加
- topic branch や worktree の具体的な選択手順は `chouge-git` に委ね、AGENTS.md には期待 outcome だけを記載

## Tests

- `git diff --check`

## Review notes

- `review-diff-code.py --mode local` を実行
- 初回 review の Design Quality finding を採用し、Git 手順との責務重複を除去
- 修正後に fresh context で再レビューし、3 reviewer すべて成功、actionable finding なし
