### PR TITLE
fix(codex): runtimeをNix管理へ移行する

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,7 +8,7 @@
           "hunk",
           "nixpkgs"
         ],
-        "systems": "systems",
+        "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -22,6 +22,25 @@
       "original": {
         "owner": "nix-community",
         "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "codex-cli-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1784658824,
+        "narHash": "sha256-TYW3rOz0V0NgXCTW+/GcdX5kNyRsMsxoS5FGRKmo0Jw=",
+        "owner": "sadjow",
+        "repo": "codex-cli-nix",
+        "rev": "bd1773d0f796c93de7f4f00ea6c2469e95e44b62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "codex-cli-nix",
         "type": "github"
       }
     },
@@ -58,6 +77,24 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -161,16 +198,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
-        "owner": "nixos",
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -205,14 +242,31 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "codex-cli-nix": "codex-cli-nix",
         "flake-parts": "flake-parts",
         "herdr": "herdr",
         "home-manager": "home-manager",
         "hunk": "hunk",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "rust-overlay": {
@@ -237,6 +291,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,8 @@
       url = "github:modem-dev/hunk";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    codex-cli-nix.url = "github:sadjow/codex-cli-nix";
   };
 
   outputs =
@@ -35,6 +37,7 @@
       home-manager,
       herdr,
       hunk,
+      codex-cli-nix,
       ...
     }:
     let
@@ -173,6 +176,7 @@
                             ;
                           herdrPackage = herdr.packages.${pkgs.system}.default;
                           hunkInput = hunk;
+                          codexCliPackage = codex-cli-nix.packages.${pkgs.system}.codex;
                         })
                       ];
                     };
@@ -207,6 +211,7 @@
                         ;
                       herdrPackage = herdr.packages.${pkgs.system}.default;
                       hunkInput = hunk;
+                      codexCliPackage = codex-cli-nix.packages.${pkgs.system}.codex;
                     })
                   ];
 

--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -6,11 +6,18 @@
   dotfilesDir,
   herdrPackage,
   hunkInput,
+  codexCliPackage,
   ...
 }:
 {
   imports = [
-    (import ./packages.nix { inherit pkgs herdrPackage; })
+    (import ./packages.nix {
+      inherit
+        pkgs
+        herdrPackage
+        codexCliPackage
+        ;
+    })
 
     (import ./programs {
       inherit

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -1,6 +1,12 @@
-{ pkgs, herdrPackage, ... }:
+{
+  pkgs,
+  herdrPackage,
+  codexCliPackage,
+  ...
+}:
 let
   python = pkgs.python313Packages;
+  agent-wrapper-dir = ".local/share/nono-agent-wrappers";
 
   azure-ai-inference = python.buildPythonPackage rec {
     pname = "azure-ai-inference";
@@ -127,28 +133,15 @@ let
 
   codex-sandboxed = pkgs.writeShellScriptBin "codex" ''
     ${canonicalize-herdr-socket}
-    codex_bin=""
-    old_ifs="$IFS"
-    IFS=:
-    for bin_dir in $PATH; do
-      candidate="$bin_dir/codex"
-      if [ -x "$candidate" ] && [ ! "$candidate" -ef "$0" ]; then
-        codex_bin="$candidate"
-        break
-      fi
-    done
-    IFS="$old_ifs"
-    if [ -z "$codex_bin" ]; then
-      echo "codex: raw executable not found on PATH" >&2
-      exit 127
-    fi
+    export CODEX_EXECUTABLE_PATH="$HOME/${agent-wrapper-dir}/codex"
+    export DISABLE_AUTOUPDATER=1
     if [ -n "''${NONO_CAP_FILE:-}" ]; then
-      exec "$codex_bin" --sandbox danger-full-access --ask-for-approval never "$@"
+      exec ${codexCliPackage}/bin/codex-raw --sandbox danger-full-access --ask-for-approval never "$@"
     fi
     HERDR_AGENT=codex exec ${nono-cli}/bin/nono run --silent \
       --profile "$HOME/.config/nono/profiles/chouge-codex.jsonc" --allow-cwd -- \
       ${codex-nono-guard} \
-      "$codex_bin" --sandbox danger-full-access --ask-for-approval never "$@"
+      ${codexCliPackage}/bin/codex-raw --sandbox danger-full-access --ask-for-approval never "$@"
   '';
 
   claude-sandboxed = pkgs.writeShellScriptBin "claude" ''
@@ -240,7 +233,7 @@ in
     RTK_TELEMETRY_DISABLED = "1";
   };
 
-  home.file.".local/share/nono-agent-wrappers".source = "${agent-wrappers}/bin";
+  home.file.${agent-wrapper-dir}.source = "${agent-wrappers}/bin";
 
   home.packages = with pkgs; [
     # Shell


### PR DESCRIPTION
Implementation-Plan:
# Codex runtime を Nix 管理へ移行する

## 目的

`codex` の公開 entrypoint を nono wrapper だけに限定し、mise が PATH を再構築しても sandbox を迂回した raw Codex が起動しない構成にする。

Codex の version、platform artifact、sandbox wrapper を dotfiles の Nix configuration で一体管理し、macOS aarch64-darwin と WSL x86_64-linux で同じ version を再現できるようにする。

## 現状

`nix/modules/home/packages.nix` は `codex-sandboxed` を生成し、`~/.local/share/nono-agent-wrappers/codex` と `home.packages` から公開している。 wrapper は PATH を走査し、自分自身ではない最初の `codex` を raw executable として選択する。

raw Codex 0.145.0 は mise 管理の Node installation に global npm package として手動導入されている。 これは dotfiles や `~/.config/mise/config.toml` の宣言対象ではない。

login shell の初期状態では wrapper が選ばれるが、`mise activate zsh` が登録した `_mise_hook` は `chpwd` と `precmd` で tool path を PATH の前方へ戻す。 実機確認では、一度 `cd` した後の `command -v codex` が `~/.local/share/mise/installs/node/24.9.0/bin/codex` へ変化した。 この経路では `NONO_CAP_FILE` が注入されず、Codex 自身の managed workspace sandbox が使われるため、nono profile が許可している repository の `.git` も read-only になり得る。

公式 npm package `@openai/codex` は JavaScript launcher と platform 別 native package で構成される。 対象 platform は `aarch64-apple-darwin` と `x86_64-unknown-linux-musl` であり、native package には Codex binary、code-mode host、resource、同梱 `rg` が含まれる。

関連する既存 contract は次にある。

- `nix/modules/home/packages.nix`: nono、agent wrapper、Home Manager package 構成
- `nono/profiles/chouge-agent-common.jsonc`: wrapper directory と開発 repository の権限
- `tests/nono-profile.sh`: Codex guard とsandbox境界の静的回帰テスト
- `flake.nix`: aarch64-darwin / x86_64-linux の build target

## 設計方針

`sadjow/codex-cli-nix` をflake inputへ追加し、そのnative Codex packageをraw runtimeとして使う。 versionとrelease artifact hashは専用flake側で管理し、dotfilesは`flake.lock`のcommit pinで受け入れたversionを固定する。 Codex更新は他のflake inputから分離し、`nix flake update codex-cli-nix`で明示的に行う。 専用flakeが提供するOpenAI公式release binaryとcode-mode hostを利用し、macOS aarch64-darwinとWSL x86_64-linuxのsource buildやartifact hash保守をdotfilesで重複させない。 Cachix substituterとtrusted keyは今回追加せず、既存のNix trust boundaryを維持する。

raw package自体は `home.packages`、`home.sessionPath`、`~/.local/share/nono-agent-wrappers` のいずれにも追加しない。 raw package は sandbox wrapper の closure dependency としてだけ到達可能にする。

`nix/modules/home/packages.nix` の `codex-sandboxed` は raw package の store path を直接参照する。 PATH走査、同名 executable の探索、`-ef` による自己除外は削除する。
外側ですでに nono capability がある場合と、新しく nono を起動する場合の双方で、同じ pinned raw executableへ到達させる。 既存の `codex-nono-guard`、`--sandbox danger-full-access`、`--ask-for-approval never`、Herdr socket canonicalization は維持する。

public command の contract は「PATH 上で利用者が起動する `codex` は `codex-sandboxed` だけ」とする。 mise、npm、その他の package manager に同名 raw executable が残っていないことは activation による削除では保証しない。 代わりに、既存 mise global Codex を一度だけ明示的に uninstall する移行手順と、切替後の検証を提示する。 uninstall と `nix run .#switch` はユーザーの明示指示なしに実行しない。

この変更は TDD の Red / Green 対象にしない。
package評価、Nix build、実際のcommand解決を主な検証手段とする。

`tests/nono-profile.sh` の既存 Codex 関連testを棚卸しし、security boundaryとして長期的に必要なcontractだけを残す。 少なくとも「nono capabilityがないchildではraw Codexを起動しない」というfail-closed contractは維持する。 一方、変数名、PATH走査loop、artifact mappingの記述形式など、Nix評価や実動作確認で十分に検出できる実装詳細をgrepするtestは追加しない。 既存testに同種の重複や、変更後に意味を失うPATH順序の前提があれば削除または統合する。
test数を維持すること自体を目標にせず、削除する場合は代わりにどのbuildまたはruntime検証が同じfailureを検出するかを明示する。

Nix変更を `nixfmt` で整形し、整理後に残ったshell test、`git diff --check`、`nix run .#build` を実行する。 build は現在のhost targetについてflake input、raw binary、wrapper closure、Home Manager構成を検証する。 WSL構成は対応systemのNix評価が可能なら実施し、現在のsandboxやdaemon制約で評価不能ならupstreamのplatform mappingと未検証riskを報告する。 実環境へ適用する場合は、switch 後に新しい shell と repository 間の `cd` を含めて `command -v codex`、`NONO_CAP_FILE`、Codex version、Git indexへの書き込みを確認する。

## 完了条件

- `codex-cli-nix` inputが`flake.lock`のcommitとcontent hashでpinされ、Codex更新を独立して実行できる。
- raw Codex derivation は public PATH に含まれず、sandbox wrapper の closure からのみ参照される。
- `codex-sandboxed` に raw executable の PATH探索がなく、絶対 store pathを使う。
- wrapper の既存 nono capability branch、guard、Codex sandbox無効化、Herdr連携が維持される。
- 既存 Codex 関連testが棚卸しされ、fail-closedなsecurity contractに必要なtestだけが残る。不要なtestを残したり、実装詳細だけを固定するtestを追加したりしない。
- 整理後に残ったshell test、`git diff --check`、`nix run .#build` が成功する。
- 適用を行う場合、repository移動後も public `codex` が同じ nono wrapperへ解決され、起動した Codex に `NONO_CAP_FILE` があり、通常の Git index更新が成功する。
- mise global Codex の手動 uninstall command、実行タイミング、切戻し方法が報告される。

## スコープ外

- `nix run .#switch` の自動実行。
- activation から mise / npm 管理領域を削除する処理。
- Codex の自動最新版追従。
- Claude、Pi、その他 agent runtime の package管理方式変更。
- nono profile のfilesystem・network capability変更。
- Herdrのagent検出や起動実装の変更。 End-Implementation-Plan