### PR TITLE
feat: implement skillをグローバル依存へ追加する

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -17,6 +17,7 @@ dependencies:
     - path: ~/ghq/github.com/nananaman/skills/meta/apm-usage
     - path: ~/ghq/github.com/nananaman/skills/meta/update-skills
     - path: ~/ghq/github.com/nananaman/skills/engineering/review-diff-code
+    - path: ~/ghq/github.com/nananaman/skills/engineering/implement
     - path: ~/ghq/github.com/nananaman/skills/engineering/tdd
     - path: ~/ghq/github.com/nananaman/skills/engineering/test-writing-style
     - path: ~/ghq/github.com/nananaman/skills/engineering/sandbox-runtime


### PR DESCRIPTION
## Summary
- user-invokedのimplement skillをグローバルAPM依存へ追加

## Changes
- `apm/apm.yml` に `~/ghq/github.com/nananaman/skills/engineering/implement` を追加

## Tests
- `git diff --cached --check`
- `apm install -g` は実行環境から `~/.apm` へのアクセスが拒否され未完了 (`Operation not permitted`)

## Review notes
- skill-workbench Review diff: path・target・既存manifest形式を確認し、actionable findingなし
- 作業開始前から存在した `explain-diff` のunstaged変更はcommitに含めていない
