### PR TITLE
feat: 成果物配信serviceを常駐させる

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -17,6 +17,7 @@ dependencies:
     - path: ~/ghq/github.com/nananaman/skills/meta/apm-usage
     - path: ~/ghq/github.com/nananaman/skills/meta/update-skills
     - path: ~/ghq/github.com/nananaman/skills/engineering/review-diff-code
+    - path: ~/ghq/github.com/nananaman/skills/engineering/explain-diff
     - path: ~/ghq/github.com/nananaman/skills/engineering/implement
     - path: ~/ghq/github.com/nananaman/skills/engineering/tdd
     - path: ~/ghq/github.com/nananaman/skills/engineering/test-writing-style
@@ -32,4 +33,5 @@ dependencies:
     - path: ~/ghq/github.com/nananaman/skills/productivity/teach
     - path: ~/ghq/github.com/nananaman/skills/productivity/handoff
     - path: ~/ghq/github.com/nananaman/skills/productivity/herdr
+    - path: ~/ghq/github.com/nananaman/skills/productivity/host-artifact
     - path: ~/ghq/github.com/nananaman/skills/productivity/improve-agent-prompt

--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -40,6 +40,14 @@
         herdrPackage
         ;
     })
+
+    (import ./host-artifact.nix {
+      inherit
+        pkgs
+        lib
+        config
+        ;
+    })
   ];
 
   home.stateVersion = "25.11";

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -11,13 +11,18 @@ let
   inherit (config.home) homeDirectory;
   inherit (config.xdg) configHome;
   agentCommonProfile = pkgs.writeText "chouge-agent-common.jsonc" (
-    builtins.replaceStrings [ "@HOME@" ] [ homeDirectory ] (
+    builtins.replaceStrings [ "@HOME@" "@BUN@" ] [ homeDirectory "${pkgs.bun}/bin/bun" ] (
       builtins.readFile ../../../nono/profiles/chouge-agent-common.jsonc
     )
   );
   agentPiProfile = pkgs.writeText "chouge-pi.jsonc" (
     builtins.replaceStrings [ "@PACKAGE_MANAGER@" ] [ "${pkgs.bun}/bin/bun" ] (
       builtins.readFile ../../../nono/profiles/chouge-pi.jsonc
+    )
+  );
+  hostArtifactServerProfile = pkgs.writeText "host-artifact-server.jsonc" (
+    builtins.replaceStrings [ "@HOME@" ] [ homeDirectory ] (
+      builtins.readFile ../../../nono/profiles/host-artifact-server.jsonc
     )
   );
 in
@@ -71,6 +76,7 @@ in
     link_force "${dotfilesDir}/nono/profiles/chouge-codex.jsonc" "${configHome}/nono/profiles/chouge-codex.jsonc"
     link_force "${dotfilesDir}/nono/profiles/chouge-claude.jsonc" "${configHome}/nono/profiles/chouge-claude.jsonc"
     link_force "${agentPiProfile}" "${configHome}/nono/profiles/chouge-pi.jsonc"
+    link_force "${hostArtifactServerProfile}" "${configHome}/nono/profiles/host-artifact-server.jsonc"
     link_force "${dotfilesDir}/apm" "${homeDirectory}/.apm"
 
     ${lib.optionalString pkgs.stdenv.isLinux ''

--- a/nix/modules/home/host-artifact.nix
+++ b/nix/modules/home/host-artifact.nix
@@ -1,0 +1,51 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  home = config.home.homeDirectory;
+  skillRoot = "${home}/.agents/skills/host-artifact";
+  serviceRoot = "${home}/.local/share/host-artifact";
+  publishRoot = "${serviceRoot}/public";
+  stateRoot = "${home}/.local/state/host-artifact";
+in
+{
+  config = lib.mkIf pkgs.stdenv.isDarwin {
+    home.activation.prepareHostArtifactDirectories = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      $DRY_RUN_CMD mkdir -p ${lib.escapeShellArg publishRoot}
+      $DRY_RUN_CMD mkdir -p ${lib.escapeShellArg stateRoot}
+    '';
+
+    home.activation.prepareHostArtifactRuntime =
+      lib.hm.dag.entryAfter [ "prepareHostArtifactDirectories" ]
+        ''
+          if [ ! -f ${lib.escapeShellArg "${skillRoot}/bun.lock"} ]; then
+            echo "host-artifact: run apm install -g before Home Manager activation" >&2
+            exit 1
+          fi
+          (
+            cd ${lib.escapeShellArg skillRoot}
+            $DRY_RUN_CMD ${pkgs.bun}/bin/bun install --frozen-lockfile --production
+          )
+        '';
+
+    launchd.agents.com-nananaman-host-artifact = {
+      enable = true;
+      config = {
+        Label = "com.nananaman.host-artifact";
+        ProgramArguments = [
+          "${home}/.local/share/nono-agent-wrappers/host-artifact-server"
+        ];
+        RunAtLoad = true;
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
+        ProcessType = "Background";
+        StandardOutPath = "${stateRoot}/host-artifact-stdout.log";
+        StandardErrorPath = "${stateRoot}/host-artifact-stderr.log";
+      };
+    };
+  };
+}

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -241,12 +241,14 @@ let
   '';
 
   host-artifact-server = pkgs.writeShellScriptBin "host-artifact-server" ''
+    tailscale_address="$(/usr/local/bin/tailscale ip -4 2>/dev/null | /usr/bin/head -n 1 || true)"
     exec ${nono-cli}/bin/nono run --silent \
       --profile "$HOME/.config/nono/profiles/host-artifact-server.jsonc" -- \
       ${pkgs.bun}/bin/bun \
       "$HOME/.agents/skills/host-artifact/src/server-main.ts" \
       --port 9417 \
-      --publish-root "$HOME/.local/share/host-artifact/public"
+      --publish-root "$HOME/.local/share/host-artifact/public" \
+      --tailscale-address "$tailscale_address"
   '';
 
   agent-wrappers = pkgs.symlinkJoin {

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -241,14 +241,22 @@ let
   '';
 
   host-artifact-server = pkgs.writeShellScriptBin "host-artifact-server" ''
-    tailscale_address="$(/usr/local/bin/tailscale ip -4 2>/dev/null | /usr/bin/head -n 1 || true)"
+    tailscale_address_file="$HOME/.local/share/host-artifact/public/.tailscale-address"
+    update_tailscale_address() {
+      /usr/local/bin/tailscale ip -4 2>/dev/null | /usr/bin/head -n 1 >"$tailscale_address_file.tmp" || true
+      /bin/mv -f "$tailscale_address_file.tmp" "$tailscale_address_file"
+    }
+    update_tailscale_address
+    while /bin/sleep 15; do
+      update_tailscale_address
+    done &
     exec ${nono-cli}/bin/nono run --silent \
       --profile "$HOME/.config/nono/profiles/host-artifact-server.jsonc" -- \
       ${pkgs.bun}/bin/bun \
       "$HOME/.agents/skills/host-artifact/src/server-main.ts" \
       --port 9417 \
       --publish-root "$HOME/.local/share/host-artifact/public" \
-      --tailscale-address "$tailscale_address"
+      --tailscale-address-file "$tailscale_address_file"
   '';
 
   agent-wrappers = pkgs.symlinkJoin {

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -191,16 +191,25 @@ let
     fi
 
     health_url="http://127.0.0.1:9417/.well-known/host-artifact/health"
-    expected_health='{"service":"host-artifact","version":1,"status":"ok"}'
+    is_expected_health() {
+      case "$1" in
+        '{"service":"host-artifact","version":1,"status":"ok"}'|'{"service":"host-artifact","version":1,"status":"ok",'*)
+          return 0
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+    }
     health_body="$(/usr/bin/curl --fail --silent --show-error --max-time 1 "$health_url" 2>/dev/null || true)"
-    if [ "$health_body" = "$expected_health" ]; then
+    if is_expected_health "$health_body"; then
       exit 0
     fi
 
     /bin/launchctl kickstart -k "gui/$UID/com.nananaman.host-artifact"
     for _attempt in $(/usr/bin/seq 1 20); do
       health_body="$(/usr/bin/curl --fail --silent --show-error --max-time 1 "$health_url" 2>/dev/null || true)"
-      if [ "$health_body" = "$expected_health" ]; then
+      if is_expected_health "$health_body"; then
         exit 0
       fi
       /bin/sleep 0.25
@@ -241,7 +250,7 @@ let
   '';
 
   host-artifact-server = pkgs.writeShellScriptBin "host-artifact-server" ''
-    tailscale_address_file="$HOME/.local/share/host-artifact/public/.tailscale-address"
+    tailscale_address_file="$HOME/.local/state/host-artifact/tailscale-address"
     update_tailscale_address() {
       /usr/local/bin/tailscale ip -4 2>/dev/null | /usr/bin/head -n 1 >"$tailscale_address_file.tmp" || true
       /bin/mv -f "$tailscale_address_file.tmp" "$tailscale_address_file"

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -184,12 +184,80 @@ let
     exec /opt/homebrew/bin/container "$@"
   '';
 
+  host-artifact-service = pkgs.writeShellScriptBin "host-artifact-service" ''
+    if [ "$#" -ne 1 ] || [ "$1" != "ensure" ]; then
+      echo "usage: host-artifact-service ensure" >&2
+      exit 64
+    fi
+
+    health_url="http://127.0.0.1:9417/.well-known/host-artifact/health"
+    expected_health='{"service":"host-artifact","version":1,"status":"ok"}'
+    health_body="$(/usr/bin/curl --fail --silent --show-error --max-time 1 "$health_url" 2>/dev/null || true)"
+    if [ "$health_body" = "$expected_health" ]; then
+      exit 0
+    fi
+
+    /bin/launchctl kickstart -k "gui/$UID/com.nananaman.host-artifact"
+    for _attempt in $(/usr/bin/seq 1 20); do
+      health_body="$(/usr/bin/curl --fail --silent --show-error --max-time 1 "$health_url" 2>/dev/null || true)"
+      if [ "$health_body" = "$expected_health" ]; then
+        exit 0
+      fi
+      /bin/sleep 0.25
+    done
+
+    echo "host-artifact-service: service did not become ready" >&2
+    exit 1
+  '';
+
+  host-artifact = pkgs.writeShellScriptBin "host-artifact" ''
+    case "''${1:-}" in
+      host)
+        if [ "$#" -ne 2 ] && { [ "$#" -ne 3 ] || [ "$3" != "--tailscale" ]; }; then
+          echo "usage: host-artifact host PATH [--tailscale]" >&2
+          exit 64
+        fi
+        ;;
+      remove)
+        if [ "$#" -ne 2 ]; then
+          echo "usage: host-artifact remove ARTIFACT_ID" >&2
+          exit 64
+        fi
+        ;;
+      status)
+        if [ "$#" -ne 1 ]; then
+          echo "usage: host-artifact status" >&2
+          exit 64
+        fi
+        ;;
+      *)
+        echo "usage: host-artifact <host PATH [--tailscale] | remove ARTIFACT_ID | status>" >&2
+        exit 64
+        ;;
+    esac
+
+    exec ${pkgs.bun}/bin/bun \
+      "$HOME/.agents/skills/host-artifact/src/cli.ts" "$@"
+  '';
+
+  host-artifact-server = pkgs.writeShellScriptBin "host-artifact-server" ''
+    exec ${nono-cli}/bin/nono run --silent \
+      --profile "$HOME/.config/nono/profiles/host-artifact-server.jsonc" -- \
+      ${pkgs.bun}/bin/bun \
+      "$HOME/.agents/skills/host-artifact/src/server-main.ts" \
+      --port 9417 \
+      --publish-root "$HOME/.local/share/host-artifact/public"
+  '';
+
   agent-wrappers = pkgs.symlinkJoin {
     name = "sandboxed-agent-wrappers";
     paths = [
       codex-sandboxed
       claude-sandboxed
       pi-sandboxed
+      host-artifact
+      host-artifact-service
+      host-artifact-server
     ]
     ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ container-sandboxed ];
   };

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -156,6 +156,7 @@
           "session": {
             "sandbox": {
               "fs_read": [
+                "/nix/store",
                 "$HOME/.agents/skills/host-artifact",
                 "$WORKDIR",
                 "$TMPDIR"

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -113,14 +113,12 @@
                 "/usr/bin/curl",
                 "/usr/bin/seq"
               ],
-              "network": {
-                "tcp_connect_ports": [9417]
-              },
               "unsafe_macos_seatbelt_rules": [
                 "(allow process-exec (literal \"/bin/launchctl\"))",
                 "(allow process-exec (literal \"/bin/sleep\"))",
                 "(allow process-exec (literal \"/usr/bin/curl\"))",
-                "(allow process-exec (literal \"/usr/bin/seq\"))"
+                "(allow process-exec (literal \"/usr/bin/seq\"))",
+                "(allow network-outbound (remote tcp \"localhost:9417\"))"
               ]
             },
             "invocation_policy": {
@@ -136,14 +134,12 @@
                 "/usr/bin/curl",
                 "/usr/bin/seq"
               ],
-              "network": {
-                "tcp_connect_ports": [9417]
-              },
               "unsafe_macos_seatbelt_rules": [
                 "(allow process-exec (literal \"/bin/launchctl\"))",
                 "(allow process-exec (literal \"/bin/sleep\"))",
                 "(allow process-exec (literal \"/usr/bin/curl\"))",
-                "(allow process-exec (literal \"/usr/bin/seq\"))"
+                "(allow process-exec (literal \"/usr/bin/seq\"))",
+                "(allow network-outbound (remote tcp \"localhost:9417\"))"
               ]
             },
             "invocation_policy": {
@@ -165,11 +161,9 @@
                 "$TMPDIR"
               ],
               "fs_write": ["$HOME/.local/share/host-artifact/public"],
-              "network": {
-                "tcp_connect_ports": [9417]
-              },
               "unsafe_macos_seatbelt_rules": [
-                "(allow process-exec (literal \"@BUN@\"))"
+                "(allow process-exec (literal \"@BUN@\"))",
+                "(allow network-outbound (remote tcp \"localhost:9417\"))"
               ]
             },
             "invocation_policy": {

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -67,6 +67,7 @@
       "$HOME/.codex",
       "$HOME/.pi",
       "$HOME/.local/state/mise",
+      "$HOME/.local/share/host-artifact/public",
       "$HOME/go/pkg/mod",
 
       // ghq管理のrepositoryを調査、clone、修正できるようにする。
@@ -79,6 +80,7 @@
     ],
     "bypass_protection": [
       "$HOME/.config/gh",
+      "$HOME/.local/share/host-artifact/public",
       "$HOME/ghq/github.com/nananaman/dotfiles/zsh/zshrc"
     ],
     "read": [
@@ -100,6 +102,87 @@
   },
   "command_policies": {
     "commands": {
+      "host-artifact-service": {
+        "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact-service",
+        "from": {
+          "session": {
+            "sandbox": {
+              "fs_read_file": [
+                "/bin/launchctl",
+                "/bin/sleep",
+                "/usr/bin/curl",
+                "/usr/bin/seq"
+              ],
+              "network": {
+                "tcp_connect_ports": [9417]
+              },
+              "unsafe_macos_seatbelt_rules": [
+                "(allow process-exec (literal \"/bin/launchctl\"))",
+                "(allow process-exec (literal \"/bin/sleep\"))",
+                "(allow process-exec (literal \"/usr/bin/curl\"))",
+                "(allow process-exec (literal \"/usr/bin/seq\"))"
+              ]
+            },
+            "invocation_policy": {
+              "default": "deny",
+              "allow": [{ "argv": { "exact": ["ensure"] } }]
+            }
+          },
+          "host-artifact": {
+            "sandbox": {
+              "fs_read_file": [
+                "/bin/launchctl",
+                "/bin/sleep",
+                "/usr/bin/curl",
+                "/usr/bin/seq"
+              ],
+              "network": {
+                "tcp_connect_ports": [9417]
+              },
+              "unsafe_macos_seatbelt_rules": [
+                "(allow process-exec (literal \"/bin/launchctl\"))",
+                "(allow process-exec (literal \"/bin/sleep\"))",
+                "(allow process-exec (literal \"/usr/bin/curl\"))",
+                "(allow process-exec (literal \"/usr/bin/seq\"))"
+              ]
+            },
+            "invocation_policy": {
+              "default": "deny",
+              "allow": [{ "argv": { "exact": ["ensure"] } }]
+            }
+          }
+        }
+      },
+      "host-artifact": {
+        "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact",
+        "can_use": ["host-artifact-service"],
+        "from": {
+          "session": {
+            "sandbox": {
+              "fs_read": [
+                "$HOME/.agents/skills/host-artifact",
+                "$WORKDIR",
+                "$TMPDIR"
+              ],
+              "fs_write": ["$HOME/.local/share/host-artifact/public"],
+              "network": {
+                "tcp_connect_ports": [9417]
+              },
+              "unsafe_macos_seatbelt_rules": [
+                "(allow process-exec (literal \"@BUN@\"))"
+              ]
+            },
+            "invocation_policy": {
+              "default": "deny",
+              "allow": [
+                { "argv": { "exact": ["status"] } },
+                { "argv": { "prefix": ["host"] } },
+                { "argv": { "prefix": ["remove"] } }
+              ]
+            }
+          }
+        }
+      },
       "container": {
         "executable": "/opt/homebrew/opt/container/libexec/container",
         "from": {

--- a/nono/profiles/host-artifact-server.jsonc
+++ b/nono/profiles/host-artifact-server.jsonc
@@ -22,7 +22,8 @@
   },
   "network": {
     "block": true,
-    "listen_port": [9417]
+    // nono 0.68.0 on macOS requires open_port for a bind exception when block is enabled.
+    "open_port": [9417]
   },
   "filesystem": {
     "read": [

--- a/nono/profiles/host-artifact-server.jsonc
+++ b/nono/profiles/host-artifact-server.jsonc
@@ -1,0 +1,34 @@
+{
+  // 常駐static serverをagent sessionとhost filesystemの双方から隔離する。
+  "meta": {
+    "name": "host-artifact-server",
+    "version": "0.1.0",
+    "description": "Read-only runtime boundary for the host-artifact server"
+  },
+  "groups": {
+    "include": [
+      // Nix-built Bunの起動と一時runtime stateに必要なmacOS pathだけを許可する。
+      "system_read_macos",
+      "system_write_macos",
+
+      // serverにcredentialと個人dataを渡さない。
+      "deny_credentials",
+      "deny_keychains_macos",
+      "deny_browser_data_macos",
+      "deny_macos_private",
+      "deny_shell_history",
+      "deny_shell_configs"
+    ]
+  },
+  "network": {
+    "block": true,
+    "listen_port": [9417]
+  },
+  "filesystem": {
+    "read": [
+      "@HOME@/.agents/skills/host-artifact",
+      "@HOME@/.local/share/host-artifact/public"
+    ],
+    "bypass_protection": ["@HOME@/.local/share/host-artifact/public"]
+  }
+}

--- a/nono/profiles/host-artifact-server.jsonc
+++ b/nono/profiles/host-artifact-server.jsonc
@@ -30,6 +30,7 @@
       "@HOME@/.agents/skills/host-artifact",
       "@HOME@/.local/share/host-artifact/public"
     ],
+    "read_file": ["@HOME@/.local/state/host-artifact/tailscale-address"],
     "bypass_protection": ["@HOME@/.local/share/host-artifact/public"]
   }
 }

--- a/tests/fixtures/host-artifact-neighbor-sentinel.txt
+++ b/tests/fixtures/host-artifact-neighbor-sentinel.txt
@@ -1,0 +1,1 @@
+must remain outside the server profile

--- a/tests/fixtures/host-artifact-public/outside-link.txt
+++ b/tests/fixtures/host-artifact-public/outside-link.txt
@@ -1,0 +1,1 @@
+../host-artifact-neighbor-sentinel.txt

--- a/tests/fixtures/host-artifact-public/report.txt
+++ b/tests/fixtures/host-artifact-public/report.txt
@@ -1,0 +1,1 @@
+host-artifact fixture

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -190,6 +190,14 @@ test_launch_agent_runs_typescript_with_bun_through_nono() {
   rg -q 'host-artifact-server\.jsonc' "$dotfiles_module"
 }
 
+test_server_wrapper_passes_the_authoritative_tailscale_address() {
+  # Arrange: The fixed host wrapper runs before the server enters its nono sandbox.
+  # Act: Inspect how it discovers and passes the Tailscale listener address.
+  # Assert: Only the Tailscale CLI result becomes the server's authoritative candidate.
+  rg -Fq '/usr/local/bin/tailscale ip -4' "$packages_module" || return 1
+  rg -Fq -- '--tailscale-address "$tailscale_address"' "$packages_module" || return 1
+}
+
 test_activation_installs_frozen_bun_dependencies_before_service_use() {
   # Arrange: APM deploys TypeScript sources without generated JavaScript or node_modules.
   # Act: Inspect the Home Manager activation contract.

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -154,7 +154,7 @@ test_server_profile_is_read_only_and_listens_only_on_the_service_port() {
       ]
   ' <<<"$profile_json" >/dev/null
   jq -e '.filesystem | has("allow") | not' <<<"$profile_json" >/dev/null
-  jq -e '.network == {"block":true,"listen_port":[9417]}' <<<"$profile_json" >/dev/null
+  jq -e '.network == {"block":true,"open_port":[9417]}' <<<"$profile_json" >/dev/null
   jq -e 'has("extends") | not' <<<"$profile_json" >/dev/null
   jq -e '
     .groups.include

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -87,7 +87,8 @@ test_ensure_wrapper_requires_the_server_identity() {
   # Act: Inspect the readiness predicate used before and after kickstart.
   # Assert: Only the versioned host-artifact health document counts as healthy.
   rg -q '\{"service":"host-artifact","version":1,"status":"ok"\}' "$packages_module"
-  rg -q '\[ "\$health_body" = "\$expected_health" \]' "$packages_module"
+  rg -q 'is_expected_health "\$health_body"' "$packages_module"
+  rg -q '\{"service":"host-artifact","version":1,"status":"ok",'\''\*' "$packages_module"
 }
 
 test_profile_grants_only_the_publish_root_and_exact_ensure_command() {
@@ -196,7 +197,21 @@ test_server_wrapper_refreshes_the_authoritative_tailscale_address() {
   # Assert: Only the Tailscale CLI result becomes the server's authoritative candidate.
   rg -Fq '/usr/local/bin/tailscale ip -4' "$packages_module" || return 1
   rg -Fq 'while /bin/sleep 15' "$packages_module" || return 1
+  rg -Fq '.local/state/host-artifact/tailscale-address' "$packages_module" || return 1
   rg -Fq -- '--tailscale-address-file "$tailscale_address_file"' "$packages_module" || return 1
+}
+
+test_server_profile_reads_only_the_protected_tailscale_address_state() {
+  local profile_json
+
+  # Arrange: Normalize the dedicated server profile.
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$server_profile")"
+
+  # Act & Assert: The server reads the exact state file without gaining state-directory write access.
+  jq -e '
+    .filesystem.read_file == ["@HOME@/.local/state/host-artifact/tailscale-address"]
+    and (.filesystem.bypass_protection | index("@HOME@/.local/state/host-artifact") == null)
+  ' <<<"$profile_json" >/dev/null || return 1
 }
 
 test_activation_installs_frozen_bun_dependencies_before_service_use() {

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -134,7 +134,12 @@ test_ensure_command_sandbox_executes_only_its_fixed_dependencies() {
   ' <<<"$profile_json" >/dev/null
   jq -e '
     .command_policies.commands["host-artifact-service"].from.session.sandbox
-      .network.tcp_connect_ports == [9417]
+      | has("network") | not
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact-service"].from.session.sandbox
+      .unsafe_macos_seatbelt_rules
+      | index("(allow network-outbound (remote tcp \"localhost:9417\"))") != null
   ' <<<"$profile_json" >/dev/null
 }
 
@@ -206,6 +211,15 @@ test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
   jq -e '
     .command_policies.commands["host-artifact"].can_use
       == ["host-artifact-service"]
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact"].from.session.sandbox
+      | has("network") | not
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact"].from.session.sandbox
+      .unsafe_macos_seatbelt_rules
+      | index("(allow network-outbound (remote tcp \"localhost:9417\"))") != null
   ' <<<"$profile_json" >/dev/null
   jq -e '
     .command_policies.commands["host-artifact"].from.session.invocation_policy

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -217,6 +217,10 @@ test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
       | has("network") | not
   ' <<<"$profile_json" >/dev/null
   jq -e '
+    .command_policies.commands["host-artifact"].from.session.sandbox.fs_read
+      | index("/nix/store") != null
+  ' <<<"$profile_json" >/dev/null || return 1
+  jq -e '
     .command_policies.commands["host-artifact"].from.session.sandbox
       .unsafe_macos_seatbelt_rules
       | index("(allow network-outbound (remote tcp \"localhost:9417\"))") != null

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -190,12 +190,13 @@ test_launch_agent_runs_typescript_with_bun_through_nono() {
   rg -q 'host-artifact-server\.jsonc' "$dotfiles_module"
 }
 
-test_server_wrapper_passes_the_authoritative_tailscale_address() {
+test_server_wrapper_refreshes_the_authoritative_tailscale_address() {
   # Arrange: The fixed host wrapper runs before the server enters its nono sandbox.
   # Act: Inspect how it discovers and passes the Tailscale listener address.
   # Assert: Only the Tailscale CLI result becomes the server's authoritative candidate.
   rg -Fq '/usr/local/bin/tailscale ip -4' "$packages_module" || return 1
-  rg -Fq -- '--tailscale-address "$tailscale_address"' "$packages_module" || return 1
+  rg -Fq 'while /bin/sleep 15' "$packages_module" || return 1
+  rg -Fq -- '--tailscale-address-file "$tailscale_address_file"' "$packages_module" || return 1
 }
 
 test_activation_installs_frozen_bun_dependencies_before_service_use() {

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+module="nix/modules/home/host-artifact.nix"
+packages_module="nix/modules/home/packages.nix"
+dotfiles_module="nix/modules/home/dotfiles.nix"
+profile="nono/profiles/chouge-agent-common.jsonc"
+server_profile="nono/profiles/host-artifact-server.jsonc"
+apm_manifest="apm/apm.yml"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/host-artifact-service-test.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+
+render_server_profile() {
+  local output="$1"
+  local repository_root
+
+  repository_root="$(pwd -P)"
+  sed \
+    -e "s|@HOME@/.agents/skills/host-artifact|$repository_root/nix/modules/home|g" \
+    -e "s|@HOME@/.local/share/host-artifact/public|$repository_root/tests/fixtures/host-artifact-public|g" \
+    "$server_profile" >"$output"
+}
+
+assert_server_path_decision() {
+  local expected="$1"
+  local target_path="$2"
+  local operation="$3"
+  local rendered_profile="$test_root/host-artifact-server.jsonc"
+  local output
+
+  # Arrange: Render the generic profile against immutable repository fixtures.
+  render_server_profile "$rendered_profile"
+
+  # Act: Ask nono to classify the exact server filesystem operation.
+  output="$(nono why --profile "$rendered_profile" --path "$target_path" --op "$operation")"
+
+  # Assert: Only the declared read-only roots cross the server boundary.
+  if [[ "${output%%$'\n'*}" != "$expected" ]]; then
+    printf 'expected %s for %s access to %s, got:\n%s\n' \
+      "$expected" "$operation" "$target_path" "$output" >&2
+    return 1
+  fi
+}
+
+test_launch_agent_uses_the_shared_service_contract() {
+  # Arrange: The service contract is shared with the installed host-artifact skill.
+  # Act: Inspect the declarative user service definition.
+  # Assert: The label, port, publish root, skill root, and health path are fixed.
+  rg -q 'com\.nananaman\.host-artifact' "$module"
+  rg -q '9417' "$packages_module"
+  rg -q '\.local/share/host-artifact' "$module"
+  rg -q 'publishRoot = ".*public"' "$module"
+  rg -q '\.agents/skills/host-artifact' "$packages_module"
+  rg -q '/\.well-known/host-artifact/health' "$packages_module"
+}
+
+test_launch_agent_is_persistent_and_has_dedicated_logs() {
+  # Arrange: A shared service must survive individual Codex sessions.
+  # Act: Inspect its lifecycle and logging declarations.
+  # Assert: Login starts it, failures restart it, and output has dedicated paths.
+  rg -q 'RunAtLoad = true' "$module"
+  rg -q 'KeepAlive' "$module"
+  rg -q 'host-artifact-stdout\.log' "$module"
+  rg -q 'host-artifact-stderr\.log' "$module"
+}
+
+test_ensure_wrapper_exposes_only_the_ensure_operation() {
+  # Arrange: The sandbox may recover one fixed LaunchAgent but may not control others.
+  # Act: Inspect the generated wrapper's argument and launchctl invocation.
+  # Assert: Only exact "ensure" is accepted and kickstart fixes the user label.
+  rg -q 'if \[ "\$#" -ne 1 \] || \[ "\$1" != "ensure" \]' "$packages_module"
+  rg -q '/bin/launchctl kickstart -k "gui/\$UID/com\.nananaman\.host-artifact"' "$packages_module"
+}
+
+test_ensure_wrapper_uses_a_finite_health_check() {
+  # Arrange: Service recovery must not leave an agent waiting indefinitely.
+  # Act: Inspect the health check and retry bounds.
+  # Assert: Requests have a timeout and readiness retries are finite.
+  rg -q '/usr/bin/curl.*--max-time' "$packages_module"
+  rg -q 'seq 1 [0-9]' "$packages_module"
+  rg -q 'http://127\.0\.0\.1:9417/\.well-known/host-artifact/health' "$packages_module"
+}
+
+test_ensure_wrapper_requires_the_server_identity() {
+  # Arrange: An unrelated process can occupy the fixed port and return HTTP 200.
+  # Act: Inspect the readiness predicate used before and after kickstart.
+  # Assert: Only the versioned host-artifact health document counts as healthy.
+  rg -q '\{"service":"host-artifact","version":1,"status":"ok"\}' "$packages_module"
+  rg -q '\[ "\$health_body" = "\$expected_health" \]' "$packages_module"
+}
+
+test_profile_grants_only_the_publish_root_and_exact_ensure_command() {
+  local profile_json
+
+  # Arrange: Strip JSONC comments so policy values can be queried structurally.
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
+
+  # Act: Select the filesystem and command capabilities added for artifact hosting.
+  # Assert: The writable path and executable are exact, and every other argv is denied.
+  jq -e '
+    .filesystem.allow
+    | index("$HOME/.local/share/host-artifact/public") != null
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .filesystem.allow
+    | index("$HOME/.local/share/host-artifact") == null
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .filesystem.bypass_protection
+    | index("$HOME/.local/share/host-artifact") == null
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact-service"]
+      .executable == "@HOME@/.local/share/nono-agent-wrappers/host-artifact-service"
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact-service"].from.session.invocation_policy
+      == {"default":"deny","allow":[{"argv":{"exact":["ensure"]}}]}
+  ' <<<"$profile_json" >/dev/null
+}
+
+test_ensure_command_sandbox_executes_only_its_fixed_dependencies() {
+  local profile_json
+
+  # Arrange: Normalize the source profile without resolving it against host state.
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
+
+  # Act: Select files executable by the fixed ensure implementation.
+  # Assert: The child sandbox exposes only launchctl and its bounded health helpers.
+  jq -e '
+    .command_policies.commands["host-artifact-service"].from.session.sandbox.fs_read_file
+      == ["/bin/launchctl", "/bin/sleep", "/usr/bin/curl", "/usr/bin/seq"]
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact-service"].from.session.sandbox
+      .network.tcp_connect_ports == [9417]
+  ' <<<"$profile_json" >/dev/null
+}
+
+test_server_profile_is_read_only_and_listens_only_on_the_service_port() {
+  local profile_json
+
+  # Arrange: Normalize the dedicated server profile as declarative policy.
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$server_profile")"
+
+  # Act: Select filesystem and network grants.
+  # Assert: The server can only read its code/content and can only listen on 9417.
+  jq -e '
+    .filesystem.read
+      == [
+        "@HOME@/.agents/skills/host-artifact",
+        "@HOME@/.local/share/host-artifact/public"
+      ]
+  ' <<<"$profile_json" >/dev/null
+  jq -e '.filesystem | has("allow") | not' <<<"$profile_json" >/dev/null
+  jq -e '.network == {"block":true,"listen_port":[9417]}' <<<"$profile_json" >/dev/null
+  jq -e 'has("extends") | not' <<<"$profile_json" >/dev/null
+  jq -e '
+    .groups.include
+      == [
+        "system_read_macos",
+        "system_write_macos",
+        "deny_credentials",
+        "deny_keychains_macos",
+        "deny_browser_data_macos",
+        "deny_macos_private",
+        "deny_shell_history",
+        "deny_shell_configs"
+      ]
+  ' <<<"$profile_json" >/dev/null
+}
+
+test_launch_agent_runs_typescript_with_bun_through_nono() {
+  # Arrange: The persistent process must not inherit the unrestricted LaunchAgent context.
+  # Act: Inspect the fixed server wrapper and LaunchAgent argv.
+  # Assert: nono applies the dedicated profile before Bun runs checked-in TypeScript.
+  rg -q 'host-artifact-server\.jsonc' "$packages_module"
+  rg -q 'nono run --silent' "$packages_module"
+  rg -Fq '${pkgs.bun}/bin/bun' "$packages_module" || return 1
+  rg -q 'src/server-main\.ts' "$packages_module" || return 1
+  if rg -q 'dist/server\.js' "$packages_module"; then return 1; fi
+  rg -q 'host-artifact-server' "$module"
+  rg -q 'hostArtifactServerProfile' "$dotfiles_module"
+  rg -q 'host-artifact-server\.jsonc' "$dotfiles_module"
+}
+
+test_activation_installs_frozen_bun_dependencies_before_service_use() {
+  # Arrange: APM deploys TypeScript sources without generated JavaScript or node_modules.
+  # Act: Inspect the Home Manager activation contract.
+  # Assert: Production dependencies are prepared from the committed Bun lockfile.
+  rg -q 'bun install --frozen-lockfile --production' "$module" || return 1
+  rg -q 'bun\.lock' "$module" || return 1
+}
+
+test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
+  local profile_json
+
+  # Arrange: Direct bun invocation is unavailable in the parent agent sandbox.
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
+
+  # Act: Inspect the wrapper and its command-policy boundary.
+  # Assert: The trusted wrapper runs only the installed CLI source with bounded public argv.
+  rg -q 'writeShellScriptBin "host-artifact"' "$packages_module" || return 1
+  rg -q 'src/cli\.ts' "$packages_module" || return 1
+  jq -e '
+    .command_policies.commands["host-artifact"].can_use
+      == ["host-artifact-service"]
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact"].from.session.invocation_policy
+      == {
+        "default":"deny",
+        "allow":[
+          {"argv":{"exact":["status"]}},
+          {"argv":{"prefix":["host"]}},
+          {"argv":{"prefix":["remove"]}}
+        ]
+      }
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact-service"]
+      .from["host-artifact"].invocation_policy
+      == {"default":"deny","allow":[{"argv":{"exact":["ensure"]}}]}
+  ' <<<"$profile_json" >/dev/null
+}
+
+test_server_profile_reads_published_content_but_not_its_neighbor() {
+  local repository_root
+  repository_root="$(pwd -P)"
+
+  # Arrange: Published content and a neighboring sentinel both exist.
+  # Act & Assert: The explicit publish root is readable and the neighbor is denied.
+  assert_server_path_decision \
+    "ALLOWED" \
+    "$repository_root/tests/fixtures/host-artifact-public/report.txt" \
+    "read"
+  assert_server_path_decision \
+    "DENIED" \
+    "$repository_root/tests/fixtures/host-artifact-neighbor-sentinel.txt" \
+    "read"
+}
+
+test_server_profile_cannot_write_published_content() {
+  local repository_root
+  repository_root="$(pwd -P)"
+
+  # Arrange: The published fixture is covered only by filesystem.read.
+  # Act & Assert: The dedicated server cannot modify agent-published content.
+  assert_server_path_decision \
+    "DENIED" \
+    "$repository_root/tests/fixtures/host-artifact-public/report.txt" \
+    "write"
+}
+
+test_server_profile_cannot_replace_the_publish_root() {
+  local repository_root
+  repository_root="$(pwd -P)"
+
+  # Arrange: Replacing "public" requires write access to its parent directory.
+  # Act & Assert: The server has no write grant on the parent that owns the root entry.
+  assert_server_path_decision \
+    "DENIED" \
+    "$repository_root/tests/fixtures" \
+    "write"
+}
+
+test_server_profile_cannot_follow_a_publish_symlink_outside_the_root() {
+  local repository_root
+  repository_root="$(pwd -P)"
+
+  # Arrange: A publish-root symlink resolves to the neighboring sentinel.
+  # Act & Assert: Canonical path enforcement denies the outside target.
+  assert_server_path_decision \
+    "DENIED" \
+    "$repository_root/tests/fixtures/host-artifact-public/outside-link.txt" \
+    "read"
+}
+
+test_apm_installs_the_host_artifact_skill() {
+  # Arrange: The LaunchAgent wrapper references the globally installed skill path.
+  # Act: Inspect the source-of-truth APM dependency list.
+  # Assert: host-artifact is installed without removing explain-diff.
+  rg -q 'path: ~/ghq/github\.com/nananaman/skills/productivity/host-artifact$' "$apm_manifest"
+  rg -q 'path: ~/ghq/github\.com/nananaman/skills/engineering/explain-diff$' "$apm_manifest"
+}
+
+test_launch_agent_uses_the_shared_service_contract
+test_launch_agent_is_persistent_and_has_dedicated_logs
+test_ensure_wrapper_exposes_only_the_ensure_operation
+test_ensure_wrapper_uses_a_finite_health_check
+test_ensure_wrapper_requires_the_server_identity
+test_profile_grants_only_the_publish_root_and_exact_ensure_command
+test_ensure_command_sandbox_executes_only_its_fixed_dependencies
+test_server_profile_is_read_only_and_listens_only_on_the_service_port
+test_launch_agent_runs_typescript_with_bun_through_nono || exit 1
+test_activation_installs_frozen_bun_dependencies_before_service_use || exit 1
+test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper || exit 1
+test_server_profile_reads_published_content_but_not_its_neighbor
+test_server_profile_cannot_write_published_content
+test_server_profile_cannot_replace_the_publish_root
+test_server_profile_cannot_follow_a_publish_symlink_outside_the_root
+test_apm_installs_the_host_artifact_skill

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -6,10 +6,19 @@ source_profile="${1:-nono/profiles/chouge-agent-common.jsonc}"
 source_profile_dir="$(dirname "$source_profile")"
 source_profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$source_profile")"
 test_config_root="$(mktemp -d "${TMPDIR:-/tmp}/nono-profile-test.XXXXXX")"
+test_publish_root="$test_config_root/host-artifact/public"
 profile_dir="$test_config_root/nono/profiles"
-mkdir -p "$profile_dir"
+mkdir -p "$profile_dir" "$test_publish_root/example"
 for source in "$source_profile_dir"/*.jsonc; do
   cp "$source" "$profile_dir/$(basename "$source")"
+done
+for copied_profile in "$profile_dir"/*.jsonc; do
+  rendered_profile="$copied_profile.rendered"
+  sed \
+    -e "s|@HOME@|$HOME|g" \
+    -e 's|$HOME/.local/share/host-artifact/public|'"$test_publish_root"'|g' \
+    "$copied_profile" >"$rendered_profile"
+  mv "$rendered_profile" "$copied_profile"
 done
 ln -s "$HOME/.config/nono/packages" "$test_config_root/nono/packages"
 trap 'rm -rf "$test_config_root"' EXIT
@@ -258,6 +267,48 @@ test_local_agent_tools_use_the_parent_sandbox() {
   done
 }
 
+test_host_artifact_publish_root_is_writable_without_broadening_its_parent() {
+  # Arrange: Artifacts are copied into one dedicated service-owned subtree.
+  # Act & Assert: The publish root is writable while an adjacent directory stays denied.
+  assert_path_decision \
+    "ALLOWED" \
+    "$test_publish_root/example/report.html" \
+    "readwrite"
+  assert_path_decision \
+    "DENIED" \
+    "$test_config_root/host-artifact-private/report.html" \
+    "readwrite"
+  assert_path_decision \
+    "DENIED" \
+    "$HOME/.local/share/host-artifact" \
+    "write"
+}
+
+test_host_artifact_service_policy_allows_only_exact_ensure() {
+  # Arrange: Service recovery is delegated through one canonical wrapper.
+  # Act & Assert: The policy defaults to deny and grants only the argument-free ensure operation.
+  assert_profile_value \
+    '.command_policies.commands["host-artifact-service"].executable' \
+    '@HOME@/.local/share/nono-agent-wrappers/host-artifact-service'
+  assert_profile_value \
+    '.command_policies.commands["host-artifact-service"].from.session.invocation_policy.default' \
+    'deny'
+  assert_profile_value \
+    '.command_policies.commands["host-artifact-service"].from.session.invocation_policy.allow | tojson' \
+    '[{"argv":{"exact":["ensure"]}}]'
+}
+
+test_host_artifact_service_policy_does_not_delegate_launchctl() {
+  # Arrange: Agents receive a fixed recovery operation rather than general service control.
+  # Act & Assert: launchctl itself has no command policy and no other wrapper argv is allowed.
+  assert_profile_value \
+    '.command_policies.commands | has("launchctl")' \
+    'false'
+  assert_profile_value \
+    '.command_policies.commands["host-artifact-service"].from.session.invocation_policy.allow | length' \
+    '1'
+}
+
 test_codex_allows_chatgpt_subscription_endpoint() {
   assert_agent_network_boundary codex chatgpt.com
 }
@@ -283,6 +334,9 @@ test_command_policies_never_require_human_approval
 test_container_wrapper_prefers_the_tool_sandbox_shim
 test_codex_wrapper_requires_the_parent_nono_capability
 test_local_agent_tools_use_the_parent_sandbox
+test_host_artifact_publish_root_is_writable_without_broadening_its_parent
+test_host_artifact_service_policy_allows_only_exact_ensure
+test_host_artifact_service_policy_does_not_delegate_launchctl
 test_codex_allows_chatgpt_subscription_endpoint
 test_claude_allows_anthropic_api_endpoint
 test_pi_allows_configured_openai_codex_endpoint


### PR DESCRIPTION
## 概要

- `host-artifact` のHono serverをLaunchAgentとして常駐化
- Bunでchecked-in TypeScriptを直接実行し、生成JavaScriptを不要化
- agent用publish境界、server専用nono profile、限定`ensure` commandを追加
- Tailscaleの確定addressを保護されたstate fileで更新し、interface変更へ追従

## 関連PR

- skill本体: https://github.com/nananaman/skills/pull/46

## 検証

- `bash tests/host-artifact-service.sh`
- `nix-instantiate --parse nix/modules/home/packages.nix`
- `nono profile validate --strict nono/profiles/host-artifact-server.jsonc`
- Home Manager build/switch、LaunchAgent、localhost/Tailscale配信の実機確認済み

## 補足

APM pinはskill repositoryの実装commitを参照しています。両PRを合わせて導入する契約です。