### PR TITLE
fix: host-artifact updateをsandboxで許可する

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -227,6 +227,12 @@ let
           exit 64
         fi
         ;;
+      update)
+        if [ "$#" -ne 3 ]; then
+          echo "usage: host-artifact update ARTIFACT_ID PATH" >&2
+          exit 64
+        fi
+        ;;
       remove)
         if [ "$#" -ne 2 ]; then
           echo "usage: host-artifact remove ARTIFACT_ID" >&2
@@ -240,7 +246,7 @@ let
         fi
         ;;
       *)
-        echo "usage: host-artifact <host PATH [--tailscale] | remove ARTIFACT_ID | status>" >&2
+        echo "usage: host-artifact <host PATH [--tailscale] | update ARTIFACT_ID PATH | remove ARTIFACT_ID | status>" >&2
         exit 64
         ;;
     esac

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -222,10 +222,16 @@ let
   host-artifact = pkgs.writeShellScriptBin "host-artifact" ''
     case "''${1:-}" in
       host)
-        if [ "$#" -ne 2 ] && { [ "$#" -ne 3 ] || [ "$3" != "--tailscale" ]; }; then
-          echo "usage: host-artifact host PATH [--tailscale]" >&2
+        if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
+          echo "usage: host-artifact host PATH [--tailscale] [--no-reload]" >&2
           exit 64
         fi
+        for flag in "''${@:3}"; do
+          if [ "$flag" != "--tailscale" ] && [ "$flag" != "--no-reload" ]; then
+            echo "usage: host-artifact host PATH [--tailscale] [--no-reload]" >&2
+            exit 64
+          fi
+        done
         ;;
       update)
         if [ "$#" -ne 3 ]; then
@@ -246,7 +252,7 @@ let
         fi
         ;;
       *)
-        echo "usage: host-artifact <host PATH [--tailscale] | update ARTIFACT_ID PATH | remove ARTIFACT_ID | status>" >&2
+        echo "usage: host-artifact <host PATH [--tailscale] [--no-reload] | update ARTIFACT_ID PATH | remove ARTIFACT_ID | status>" >&2
         exit 64
         ;;
     esac

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -172,6 +172,7 @@
               "allow": [
                 { "argv": { "exact": ["status"] } },
                 { "argv": { "prefix": ["host"] } },
+                { "argv": { "prefix": ["update"] } },
                 { "argv": { "prefix": ["remove"] } }
               ]
             }

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -256,6 +256,7 @@ test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
         "allow":[
           {"argv":{"exact":["status"]}},
           {"argv":{"prefix":["host"]}},
+          {"argv":{"prefix":["update"]}},
           {"argv":{"prefix":["remove"]}}
         ]
       }

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -232,6 +232,7 @@ test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
   # Assert: The trusted wrapper runs only the installed CLI source with bounded public argv.
   rg -q 'writeShellScriptBin "host-artifact"' "$packages_module" || return 1
   rg -q 'src/cli\.ts' "$packages_module" || return 1
+  rg -q -- '--no-reload' "$packages_module" || return 1
   jq -e '
     .command_policies.commands["host-artifact"].can_use
       == ["host-artifact-service"]


### PR DESCRIPTION
## Summary
- `host-artifact update` をagent sandboxから実行できるようにする
- HTML live reloadの既定化と`--no-reload`をdotfiles runtimeへ統合する

## Changes
- host-artifact wrapperへ`update ARTIFACT_ID PATH`の引数検証を追加
- host wrapperで`--tailscale`と`--no-reload`だけを許可
- nono command policyへ`update` branchを追加
- wrapperとpolicyの整合をcontract testで固定

## Tests
- focused RED: update branchと`--no-reload`がwrapper contractに存在しないことを確認
- `bash tests/host-artifact-service.sh` — passed
- `git diff --check` — passed
- Home Manager適用後の実機smoke — localhost / Tailscale listener ready、同一URLの自動reload成功

## Review notes
- `review-diff-code`: Sandbox Contract + blind Adversarial
- initial integration diffはactionable finding 0
- `--no-reload` follow-upは既存host prefix内のwrapper引数境界だけを拡張
- 対応するskills PR: https://github.com/nananaman/skills/pull/47
