### PR TITLE
feat(host-artifact)!: 配信helperとsandbox境界を刷新する

### DIFF
--- a/nix/modules/home/host-artifact-tailscale.sh
+++ b/nix/modules/home/host-artifact-tailscale.sh
@@ -1,0 +1,94 @@
+set -euo pipefail
+
+tailscale_bin=""
+if [ -x "@TAILSCALE_WRAPPER@" ]; then
+  tailscale_bin="@TAILSCALE_WRAPPER@"
+elif [ -x "@TAILSCALE_APP@" ]; then
+  tailscale_bin="@TAILSCALE_APP@"
+fi
+curl_bin="@CURL@"
+jq_bin="@JQ@"
+grep_bin="@GREP@"
+tr_bin="@TR@"
+target="http://127.0.0.1:9417"
+
+unavailable() {
+  "$jq_bin" -cn --arg reason "$1" '{schemaVersion:1,available:false,configured:false,reason:$reason}'
+}
+
+inspect() {
+  if [ -z "$tailscale_bin" ]; then unavailable "tailscale-not-installed"; return; fi
+  if ! status_json="$($tailscale_bin status --json 2>/dev/null)"; then
+    echo "host-artifact-tailscale: status failed" >&2
+    return 1
+  fi
+  if ! printf '%s' "$status_json" | "$jq_bin" -e '.Self.Online == true and (.Self.DNSName | type == "string")' >/dev/null 2>&1; then
+    unavailable "tailscale-offline"; return
+  fi
+  dns_name="$(printf '%s' "$status_json" | "$jq_bin" -r '.Self.DNSName | sub("[.]$";"")')"
+  dns_name="$(printf '%s' "$dns_name" | "$tr_bin" '[:upper:]' '[:lower:]')"
+  if [ -z "$dns_name" ] || [ "${#dns_name}" -gt 253 ] || \
+    [[ ! "$dns_name" =~ ^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then
+    echo "host-artifact-tailscale: invalid Self.DNSName" >&2
+    return 1
+  fi
+  if ! serve_json="$($tailscale_bin serve status --json 2>/dev/null)"; then
+    echo "host-artifact-tailscale: serve status failed" >&2
+    return 1
+  fi
+  if ! printf '%s' "$serve_json" | "$jq_bin" -e . >/dev/null 2>&1; then
+    echo "host-artifact-tailscale: malformed serve status" >&2; return 1
+  fi
+  root_state="$(printf '%s' "$serve_json" | "$jq_bin" -r --arg target "$target" --arg webKey "$dns_name:443" '
+    [.Web[$webKey]?.Handlers? | select(type == "object") | .["/"]? | select(. != null)] as $handlers
+    | if ($handlers | length) == 0 then "empty"
+      elif all($handlers[]; type == "object" and keys == ["Proxy"] and .Proxy == $target) then "configured"
+      else "conflict"
+      end
+  ' 2>/dev/null)"
+  if [ "$root_state" = "configured" ]; then
+    "$jq_bin" -cn --arg origin "https://$dns_name" '{schemaVersion:1,available:true,configured:true,origin:$origin}'
+  elif [ "$root_state" = "empty" ]; then
+    "$jq_bin" -cn '{schemaVersion:1,available:true,configured:false,reason:"serve-unconfigured"}'
+  else
+    echo "host-artifact-tailscale: conflicting root Serve target" >&2; return 1
+  fi
+}
+
+case "${1:-}" in
+  inspect)
+    [ "$#" -eq 1 ] || { echo "usage: host-artifact-tailscale inspect" >&2; exit 64; }
+    inspect
+    ;;
+  setup)
+    [ "$#" -eq 1 ] || { echo "usage: host-artifact-tailscale setup" >&2; exit 64; }
+    before="$(inspect)" || exit $?
+    if ! printf '%s' "$before" | "$jq_bin" -e '.available == true' >/dev/null; then printf '%s\n' "$before"; exit 0; fi
+    if printf '%s' "$before" | "$jq_bin" -e '.configured == true' >/dev/null; then printf '%s\n' "$before"; exit 0; fi
+    "$tailscale_bin" serve --bg --https=443 "$target" >/dev/null
+    inspect
+    ;;
+  verify)
+    [ "$#" -eq 4 ] || { echo "usage: host-artifact-tailscale verify WORKSPACE ARTIFACT REVISION" >&2; exit 64; }
+    workspace="$2"; artifact="$3"; revision="$4"
+    [[ "$workspace" =~ ^[a-z0-9][a-z0-9-]{0,47}~[a-f0-9]{12}$ ]] || exit 64
+    [[ "$artifact" =~ ^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$ ]] || exit 64
+    [[ "$artifact" != *--* ]] || exit 64
+    [[ "$revision" =~ ^r-[a-f0-9]{32}$ ]] || exit 64
+    state="$(inspect)" || exit $?
+    if ! origin="$(printf '%s' "$state" | "$jq_bin" -er 'select(.configured == true) | .origin')"; then
+      "$jq_bin" -cn '{schemaVersion:1,verified:false,reason:"serve-unavailable"}'
+      exit 0
+    fi
+    url="$origin/a/$workspace/$artifact/"
+    response="$($curl_bin --silent --show-error --max-time 3 --retry 2 --head \
+      --write-out 'Host-Artifact-Status: %{http_code}\n' "$url" 2>/dev/null || true)"
+    if printf '%s\n' "$response" | "$tr_bin" -d '\r' | "$grep_bin" -Eq '^Host-Artifact-Status: 2[0-9][0-9]$' && \
+      printf '%s\n' "$response" | "$tr_bin" -d '\r' | "$grep_bin" -Fqx "X-Host-Artifact-Revision: $revision"; then
+      "$jq_bin" -cn --arg url "$url" '{schemaVersion:1,verified:true,url:$url}'
+    else
+      "$jq_bin" -cn '{schemaVersion:1,verified:false,reason:"remote-verification-failed"}'
+    fi
+    ;;
+  *) echo "usage: host-artifact-tailscale <inspect|setup|verify WORKSPACE ARTIFACT REVISION>" >&2; exit 64 ;;
+esac

--- a/nix/modules/home/host-artifact-workspace.sh
+++ b/nix/modules/home/host-artifact-workspace.sh
@@ -1,0 +1,59 @@
+set -euo pipefail
+
+if [ "$#" -ne 1 ] || [ "$1" != "resolve" ]; then
+  echo "usage: host-artifact-workspace resolve" >&2
+  exit 64
+fi
+
+git_bin="@GIT@"
+jq_bin="@JQ@"
+shasum_bin="@SHASUM@"
+sed_bin="@SED@"
+tr_bin="@TR@"
+cut_bin="@CUT@"
+GIT_CONFIG_NOSYSTEM=1
+GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM GIT_CONFIG_GLOBAL
+cwd="$(pwd -P)"
+canonical="$cwd"
+display="${cwd##*/}"
+
+if root="$($git_bin rev-parse --show-toplevel 2>/dev/null)"; then
+  remote="$($git_bin -C "$root" config --local --get remote.origin.url 2>/dev/null || true)"
+  host=""
+  path=""
+  case "$remote" in
+    *://*)
+      without_scheme="${remote#*://}"
+      host_and_path="${without_scheme#*@}"
+      host="${host_and_path%%/*}"
+      path="${host_and_path#*/}"
+      ;;
+    *@*:*|[A-Za-z0-9.-]*:*)
+      host_and_path="${remote#*@}"
+      host="${host_and_path%%:*}"
+      path="${host_and_path#*:}"
+      ;;
+  esac
+  path="${path%/}"
+  path="${path%.git}"
+  if [ -n "$host" ] && [ -n "$path" ] && [ "$path" != "$host_and_path" ]; then
+    host="$(printf '%s' "$host" | "$tr_bin" '[:upper:]' '[:lower:]')"
+    canonical="$host/$path"
+    display="${path#*/}"
+    case "$path" in
+      */*) owner="${path%/*}"; display="${owner##*/}/${path##*/}" ;;
+    esac
+  else
+    canonical="$(cd "$root" && pwd -P)"
+    display="${canonical##*/}"
+  fi
+fi
+
+prefix="$(printf '%s' "$display" | "$tr_bin" '[:upper:]' '[:lower:]' | "$sed_bin" -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | "$cut_bin" -c1-48 | "$sed_bin" -E 's/-+$//')"
+[ -n "$prefix" ] || prefix="workspace"
+digest="$(printf '%s' "$canonical" | "$shasum_bin" -a 256 | "$cut_bin" -c1-12)"
+segment="$prefix~$digest"
+
+"$jq_bin" -cn --arg segment "$segment" --arg displayName "$display" \
+  '{schemaVersion:1,status:"ok",workspace:{segment:$segment,displayName:$displayName}}'

--- a/nix/modules/home/host-artifact.sh
+++ b/nix/modules/home/host-artifact.sh
@@ -1,0 +1,46 @@
+set -euo pipefail
+
+case "${1:-}" in
+  publish)
+    if [ "$#" -ne 4 ] || [ "$3" != "--name" ]; then
+      echo "usage: host-artifact publish PATH --name NAME" >&2
+      exit 64
+    fi
+    ;;
+  remove)
+    if [ "$#" -ne 3 ] || [ "$2" != "--name" ]; then
+      echo "usage: host-artifact remove --name NAME" >&2
+      exit 64
+    fi
+    ;;
+  status|setup)
+    if [ "$#" -ne 1 ]; then
+      echo "usage: host-artifact ${1}" >&2
+      exit 64
+    fi
+    ;;
+  *)
+    echo "usage: host-artifact <publish PATH --name NAME | remove --name NAME | status | setup>" >&2
+    exit 64
+    ;;
+esac
+
+shim_dir="${NONO_TOOL_SANDBOX_SHIM_DIR:-}"
+case "$shim_dir" in
+  /*) ;;
+  *) echo "host-artifact: command-policy shim directory is unavailable" >&2; exit 69 ;;
+esac
+if [ ! -d "$shim_dir" ]; then
+  echo "host-artifact: command-policy shim directory is unavailable" >&2
+  exit 69
+fi
+for helper in host-artifact-service host-artifact-tailscale host-artifact-workspace; do
+  if [ ! -x "$shim_dir/$helper" ]; then
+    echo "host-artifact: required command-policy shim is unavailable: $helper" >&2
+    exit 69
+  fi
+done
+PATH="$shim_dir:$PATH"
+export PATH
+
+exec @BUN@ @CLI@ "$@"

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -193,7 +193,7 @@ let
     health_url="http://127.0.0.1:9417/.well-known/host-artifact/health"
     is_expected_health() {
       case "$1" in
-        '{"service":"host-artifact","version":1,"status":"ok"}'|'{"service":"host-artifact","version":1,"status":"ok",'*)
+        '{"service":"host-artifact","version":2,"status":"ok"}'|'{"service":"host-artifact","version":2,"status":"ok",'*)
           return 0
           ;;
         *)
@@ -219,51 +219,29 @@ let
     exit 1
   '';
 
-  host-artifact = pkgs.writeShellScriptBin "host-artifact" ''
-    case "''${1:-}" in
-      host)
-        if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
-          echo "usage: host-artifact host PATH [--tailscale] [--no-reload]" >&2
-          exit 64
-        fi
-        for flag in "''${@:3}"; do
-          if [ "$flag" != "--tailscale" ] && [ "$flag" != "--no-reload" ]; then
-            echo "usage: host-artifact host PATH [--tailscale] [--no-reload]" >&2
-            exit 64
-          fi
-        done
-        ;;
-      update)
-        if [ "$#" -ne 3 ]; then
-          echo "usage: host-artifact update ARTIFACT_ID PATH" >&2
-          exit 64
-        fi
-        ;;
-      remove)
-        if [ "$#" -ne 2 ]; then
-          echo "usage: host-artifact remove ARTIFACT_ID" >&2
-          exit 64
-        fi
-        ;;
-      status)
-        if [ "$#" -ne 1 ]; then
-          echo "usage: host-artifact status" >&2
-          exit 64
-        fi
-        ;;
-      *)
-        echo "usage: host-artifact <host PATH [--tailscale] [--no-reload] | update ARTIFACT_ID PATH | remove ARTIFACT_ID | status>" >&2
-        exit 64
-        ;;
-    esac
+  host-artifact = pkgs.writeShellScriptBin "host-artifact" (
+    builtins.replaceStrings
+      [ "@BUN@" "@CLI@" ]
+      [ "${pkgs.bun}/bin/bun" "$HOME/.agents/skills/host-artifact/src/cli.ts" ]
+      (builtins.readFile ./host-artifact.sh)
+  );
 
-    exec ${pkgs.bun}/bin/bun \
-      "$HOME/.agents/skills/host-artifact/src/cli.ts" "$@"
-  '';
+  host-artifact-tailscale = pkgs.writeShellScriptBin "host-artifact-tailscale" (
+    builtins.replaceStrings
+      [ "@TAILSCALE_WRAPPER@" "@TAILSCALE_APP@" "@CURL@" "@JQ@" "@GREP@" "@TR@" ]
+      [ "/usr/local/bin/tailscale" "/Applications/Tailscale.app/Contents/MacOS/tailscale" "/usr/bin/curl" "${pkgs.jq}/bin/jq" "/usr/bin/grep" "/usr/bin/tr" ]
+      (builtins.readFile ./host-artifact-tailscale.sh)
+  );
+
+  host-artifact-workspace = pkgs.writeShellScriptBin "host-artifact-workspace" (
+    builtins.replaceStrings
+      [ "@GIT@" "@JQ@" "@SHASUM@" "@SED@" "@TR@" "@CUT@" ]
+      [ "/usr/bin/git" "${pkgs.jq}/bin/jq" "/usr/bin/shasum" "/usr/bin/sed" "/usr/bin/tr" "/usr/bin/cut" ]
+      (builtins.readFile ./host-artifact-workspace.sh)
+  );
 
   host-artifact-server = pkgs.writeShellScriptBin "host-artifact-server" ''
     skill_root="$HOME/.agents/skills/host-artifact"
-    tailscale_address_file="$HOME/.local/state/host-artifact/tailscale-address"
     host_artifact_runtime_fingerprint() {
       {
         ${pkgs.findutils}/bin/find "$skill_root/src" -type f -exec ${pkgs.coreutils}/bin/sha256sum {} \;
@@ -274,23 +252,13 @@ let
         done
       } | ${pkgs.coreutils}/bin/sort | ${pkgs.coreutils}/bin/sha256sum
     }
-    update_tailscale_address() {
-      /usr/local/bin/tailscale ip -4 2>/dev/null | /usr/bin/head -n 1 >"$tailscale_address_file.tmp" || true
-      /bin/mv -f "$tailscale_address_file.tmp" "$tailscale_address_file"
-    }
     runtime_fingerprint="$(host_artifact_runtime_fingerprint)"
-    update_tailscale_address
-    while /bin/sleep 15; do
-      update_tailscale_address
-    done &
-    tailscale_updater_pid=$!
     ${nono-cli}/bin/nono run --silent \
       --profile "$HOME/.config/nono/profiles/host-artifact-server.jsonc" -- \
       ${pkgs.bun}/bin/bun \
       "$skill_root/src/server-main.ts" \
       --port 9417 \
-      --publish-root "$HOME/.local/share/host-artifact/public" \
-      --tailscale-address-file "$tailscale_address_file" &
+      --publish-root "$HOME/.local/share/host-artifact/public" &
     server_pid=$!
 
     while /bin/kill -0 "$server_pid" 2>/dev/null; do
@@ -298,14 +266,12 @@ let
       if [ "$(host_artifact_runtime_fingerprint)" != "$runtime_fingerprint" ]; then
         /bin/kill -TERM "$server_pid"
         wait "$server_pid" 2>/dev/null || true
-        /bin/kill -TERM "$tailscale_updater_pid" 2>/dev/null || true
         exit 75
       fi
     done
 
     wait "$server_pid"
     server_exit=$?
-    /bin/kill -TERM "$tailscale_updater_pid" 2>/dev/null || true
     exit "$server_exit"
   '';
 
@@ -316,6 +282,8 @@ let
       claude-sandboxed
       pi-sandboxed
       host-artifact
+      host-artifact-tailscale
+      host-artifact-workspace
       host-artifact-service
       host-artifact-server
     ]

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -157,7 +157,7 @@
       },
       "host-artifact": {
         "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact",
-        "can_use": ["host-artifact-service"],
+        "can_use": ["host-artifact-service", "host-artifact-tailscale", "host-artifact-workspace"],
         "from": {
           "session": {
             "sandbox": {
@@ -167,9 +167,11 @@
                 "$WORKDIR",
                 "$TMPDIR"
               ],
+              "fs_read_file": ["/usr/bin/shlock"],
               "fs_write": ["$HOME/.local/share/host-artifact/public"],
               "unsafe_macos_seatbelt_rules": [
                 "(allow process-exec (literal \"@BUN@\"))",
+                "(allow process-exec (literal \"/usr/bin/shlock\"))",
                 "(allow network-outbound (remote tcp \"localhost:9417\"))"
               ]
             },
@@ -177,10 +179,74 @@
               "default": "deny",
               "allow": [
                 { "argv": { "exact": ["status"] } },
-                { "argv": { "prefix": ["host"] } },
-                { "argv": { "prefix": ["update"] } },
+                { "argv": { "exact": ["setup"] } },
+                { "argv": { "prefix": ["publish"] } },
                 { "argv": { "prefix": ["remove"] } }
               ]
+            }
+          }
+        }
+      },
+      "host-artifact-tailscale": {
+        "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact-tailscale",
+        "from": {
+          "host-artifact": {
+            "sandbox": {
+              "environment": { "allow_vars": ["HOME", "WORKDIR", "TMPDIR", "PATH", "LANG", "LC_*"] },
+              "fs_read": ["/nix/store"],
+              "fs_read_file": [
+                "/bin/sh",
+                "/usr/local/bin/tailscale",
+                "/Applications/Tailscale.app/Contents/MacOS/tailscale",
+                "/usr/bin/curl",
+                "/usr/bin/grep",
+                "/usr/bin/tr"
+              ],
+              "unsafe_macos_seatbelt_rules": [
+                "(allow process-exec (subpath \"/nix/store\"))",
+                "(allow process-exec (literal \"/bin/sh\"))",
+                "(allow process-exec (literal \"/usr/local/bin/tailscale\"))",
+                "(allow process-exec (literal \"/Applications/Tailscale.app/Contents/MacOS/tailscale\"))",
+                "(allow process-exec (literal \"/usr/bin/curl\"))",
+                "(allow process-exec (literal \"/usr/bin/grep\"))",
+                "(allow process-exec (literal \"/usr/bin/tr\"))",
+                "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))",
+                "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spki\"))",
+                "(allow network-outbound (remote tcp \"localhost:*\"))",
+                "(allow network-outbound (remote tcp \"*:443\"))"
+              ]
+            },
+            "invocation_policy": {
+              "default": "deny",
+              "allow": [
+                { "argv": { "exact": ["inspect"] } },
+                { "argv": { "exact": ["setup"] } },
+                { "argv": { "prefix": ["verify"] } }
+              ]
+            }
+          }
+        }
+      },
+      "host-artifact-workspace": {
+        "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact-workspace",
+        "from": {
+          "host-artifact": {
+            "sandbox": {
+              "environment": { "allow_vars": ["HOME", "WORKDIR", "TMPDIR", "PATH", "LANG", "LC_*"] },
+              "fs_read": ["$WORKDIR", "$HOME/ghq", "/nix/store"],
+              "fs_read_file": ["/usr/bin/git", "/usr/bin/shasum", "/usr/bin/sed", "/usr/bin/tr", "/usr/bin/cut"],
+              "unsafe_macos_seatbelt_rules": [
+                "(allow process-exec (subpath \"/nix/store\"))",
+                "(allow process-exec (literal \"/usr/bin/git\"))",
+                "(allow process-exec (literal \"/usr/bin/shasum\"))",
+                "(allow process-exec (literal \"/usr/bin/sed\"))",
+                "(allow process-exec (literal \"/usr/bin/tr\"))",
+                "(allow process-exec (literal \"/usr/bin/cut\"))"
+              ]
+            },
+            "invocation_policy": {
+              "default": "deny",
+              "allow": [{ "argv": { "exact": ["resolve"] } }]
             }
           }
         }

--- a/nono/profiles/host-artifact-server.jsonc
+++ b/nono/profiles/host-artifact-server.jsonc
@@ -30,7 +30,6 @@
       "@HOME@/.agents/skills/host-artifact",
       "@HOME@/.local/share/host-artifact/public"
     ],
-    "read_file": ["@HOME@/.local/state/host-artifact/tailscale-address"],
     "bypass_protection": ["@HOME@/.local/share/host-artifact/public"]
   }
 }

--- a/tests/fixtures/fake-curl.sh
+++ b/tests/fixtures/fake-curl.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'HTTP/2 %s\r\nX-Host-Artifact-Revision: %s\r\n\r\n' "${FAKE_CURL_STATUS:-200}" "$FAKE_CURL_REVISION"
+printf 'Host-Artifact-Status: %s\n' "${FAKE_CURL_STATUS:-200}"

--- a/tests/fixtures/fake-host-artifact-bun.sh
+++ b/tests/fixtures/fake-host-artifact-bun.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shift
+for helper in host-artifact-service host-artifact-tailscale host-artifact-workspace; do
+  resolved="$(command -v "$helper")"
+  case "$resolved" in
+    "$NONO_TOOL_SANDBOX_SHIM_DIR"/*) ;;
+    *) echo "helper bypassed shim: $helper -> $resolved" >&2; exit 1 ;;
+  esac
+done
+printf '%s\n' "$*" >>"$HOST_ARTIFACT_FAKE_BUN_LOG"

--- a/tests/fixtures/fake-tailscale.sh
+++ b/tests/fixtures/fake-tailscale.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  "status --json")
+    if [ "${FAKE_TAILSCALE_STATUS_FAIL:-0}" = 1 ]; then exit 1; fi
+    cat "$FAKE_TAILSCALE_STATUS"
+    ;;
+  "serve status --json")
+    if [ "${FAKE_TAILSCALE_SERVE_FAIL:-0}" = 1 ]; then exit 1; fi
+    cat "$FAKE_TAILSCALE_SERVE"
+    ;;
+  "serve --bg --https=443 http://127.0.0.1:9417")
+    if [ -n "${FAKE_TAILSCALE_MUTATION_LOG:-}" ]; then printf 'serve\n' >>"$FAKE_TAILSCALE_MUTATION_LOG"; fi
+    cp "$FAKE_TAILSCALE_AFTER_SETUP" "$FAKE_TAILSCALE_SERVE"
+    ;;
+  *) echo "unexpected tailscale argv: $*" >&2; exit 64 ;;
+esac

--- a/tests/host-artifact-helpers.sh
+++ b/tests/host-artifact-helpers.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/host-artifact-helper-test.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+repository_root="$(pwd -P)"
+
+render_helpers() {
+  cp "$repository_root/tests/fixtures/fake-tailscale.sh" "$test_root/tailscale"
+  cp "$repository_root/tests/fixtures/fake-curl.sh" "$test_root/curl"
+  chmod +x "$test_root/tailscale" "$test_root/curl"
+  sed -e "s|@TAILSCALE_WRAPPER@|$test_root/tailscale|g" -e "s|@TAILSCALE_APP@|$test_root/missing-tailscale|g" \
+    -e "s|@CURL@|$test_root/curl|g" \
+    -e "s|@JQ@|$(command -v jq)|g" -e "s|@GREP@|/usr/bin/grep|g" -e "s|@TR@|/usr/bin/tr|g" \
+    nix/modules/home/host-artifact-tailscale.sh >"$test_root/tailscale-helper"
+  sed -e "s|@GIT@|$(command -v git)|g" -e "s|@JQ@|$(command -v jq)|g" \
+    -e "s|@SHASUM@|/usr/bin/shasum|g" -e "s|@SED@|/usr/bin/sed|g" \
+    -e "s|@TR@|/usr/bin/tr|g" -e "s|@CUT@|/usr/bin/cut|g" \
+    nix/modules/home/host-artifact-workspace.sh >"$test_root/workspace-helper"
+}
+
+test_public_wrapper_prefers_command_policy_shims_for_every_operation() {
+  local operation
+
+  # Arrange: Trusted wrappers precede the broker shim directory in the inherited PATH.
+  mkdir "$test_root/wrappers" "$test_root/shims"
+  cp "$repository_root/tests/fixtures/fake-host-artifact-bun.sh" "$test_root/fake-bun"
+  chmod +x "$test_root/fake-bun"
+  for helper in host-artifact-service host-artifact-tailscale host-artifact-workspace; do
+    printf '#!/bin/sh\nexit 1\n' >"$test_root/wrappers/$helper"
+    printf '#!/bin/sh\nexit 0\n' >"$test_root/shims/$helper"
+    chmod +x "$test_root/wrappers/$helper" "$test_root/shims/$helper"
+  done
+  sed -e "s|@BUN@|$test_root/fake-bun|g" -e "s|@CLI@|$test_root/cli.ts|g" \
+    nix/modules/home/host-artifact.sh >"$test_root/host-artifact"
+  : >"$test_root/bun.log"
+
+  # Act: Exercise every accepted public operation through the generated wrapper.
+  for operation in 'publish report.html --name report' 'remove --name report' 'status' 'setup'; do
+    PATH="$test_root/wrappers:/usr/bin:/bin" NONO_TOOL_SANDBOX_SHIM_DIR="$test_root/shims" \
+      HOST_ARTIFACT_FAKE_BUN_LOG="$test_root/bun.log" bash "$test_root/host-artifact" $operation
+  done
+
+  # Assert: Bun observed all operations only after every helper resolved to a policy shim.
+  [ "$(wc -l <"$test_root/bun.log" | tr -d ' ')" -eq 4 ]
+}
+
+write_online_status() {
+  printf '%s\n' '{"Self":{"Online":true,"DNSName":"machine.tailnet.ts.net."}}' >"$test_root/status.json"
+}
+
+test_inspect_reports_configured_serve_without_exposing_external_state() {
+  # Arrange: Tailscale is online and the HTTPS root proxies the fixed loopback service.
+  write_online_status
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9417"}}}}}' >"$test_root/serve.json"
+
+  # Act: Inspect through fake Tailscale output.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" bash "$test_root/tailscale-helper" inspect)"
+
+  # Assert: Only the stable origin and transport state cross the helper boundary.
+  jq -e '. == {schemaVersion:1,available:true,configured:true,origin:"https://machine.tailnet.ts.net"}' <<<"$output" >/dev/null
+}
+
+test_inspect_rejects_conflicting_root_target() {
+  # Arrange: A pre-existing root route belongs to another service.
+  write_online_status
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9999"}}}}}' >"$test_root/serve.json"
+
+  # Act & Assert: Inspection fails instead of overwriting or accepting the route.
+  if FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    bash "$test_root/tailscale-helper" inspect >/dev/null 2>&1; then return 1; fi
+}
+
+test_inspect_fails_closed_when_serve_status_fails() {
+  # Arrange: Node status succeeds but Serve state cannot be obtained authoritatively.
+  write_online_status
+  : >"$test_root/serve.json"
+
+  # Act & Assert: Inspection fails instead of misreporting an unconfigured transport.
+  if FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_TAILSCALE_SERVE_FAIL=1 bash "$test_root/tailscale-helper" inspect >/dev/null 2>&1; then return 1; fi
+}
+
+test_inspect_fails_closed_when_node_status_command_fails() {
+  # Arrange: The Tailscale CLI exists but cannot reach its local backend.
+  write_online_status
+  printf '%s\n' '{}' >"$test_root/serve.json"
+
+  # Act & Assert: Command failure is distinct from an explicit offline JSON document.
+  if FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_STATUS_FAIL=1 \
+    FAKE_TAILSCALE_SERVE="$test_root/serve.json" bash "$test_root/tailscale-helper" inspect >/dev/null 2>&1; then return 1; fi
+}
+
+test_inspect_fails_closed_for_empty_online_dns_name() {
+  # Arrange: The node claims to be online without an authoritative MagicDNS hostname.
+  printf '%s\n' '{"Self":{"Online":true,"DNSName":""}}' >"$test_root/status.json"
+  printf '%s\n' '{}' >"$test_root/serve.json"
+
+  # Act & Assert: Inspection fails before querying an ambiguous :443 Serve key.
+  if FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    bash "$test_root/tailscale-helper" inspect >/dev/null 2>&1; then return 1; fi
+}
+
+test_setup_rejects_malformed_online_dns_name_without_mutation() {
+  # Arrange: An online response contains a hostname that cannot be a DNS FQDN.
+  printf '%s\n' '{"Self":{"Online":true,"DNSName":"bad..tailnet.ts.net."}}' >"$test_root/status.json"
+  printf '%s\n' '{}' >"$test_root/serve.json"
+  : >"$test_root/mutations.log"
+
+  # Act: Attempt setup while recording every mutating fake Tailscale call.
+  if FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_TAILSCALE_MUTATION_LOG="$test_root/mutations.log" bash "$test_root/tailscale-helper" setup >/dev/null 2>&1; then return 1; fi
+
+  # Assert: Invalid DNS state fails before Serve mutation.
+  [ ! -s "$test_root/mutations.log" ]
+}
+
+test_setup_does_not_mutate_when_serve_status_fails() {
+  # Arrange: Serve status is unavailable and mutation calls are recorded.
+  write_online_status
+  : >"$test_root/serve.json"
+  : >"$test_root/mutations.log"
+
+  # Act: Attempt setup without an authoritative pre-mutation Serve state.
+  if FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_TAILSCALE_SERVE_FAIL=1 FAKE_TAILSCALE_MUTATION_LOG="$test_root/mutations.log" \
+    bash "$test_root/tailscale-helper" setup >/dev/null 2>&1; then return 1; fi
+
+  # Assert: Failure is closed before the mutating subcommand.
+  [ ! -s "$test_root/mutations.log" ]
+}
+
+test_inspect_ignores_other_hosts_and_non_https_ports() {
+  # Arrange: The current DNS HTTPS root is correct while unrelated routes coexist.
+  write_online_status
+  printf '%s\n' '{"Web":{
+    "machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9417"}}},
+    "machine.tailnet.ts.net:80":{"Handlers":{"/":{"Text":"redirect"}}},
+    "other.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9999"}}}
+  }}' >"$test_root/serve.json"
+
+  # Act: Inspect the authoritative current-node HTTPS entry.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" bash "$test_root/tailscale-helper" inspect)"
+
+  # Assert: Unrelated host/port handlers do not create a false conflict.
+  jq -e '.available and .configured and .origin == "https://machine.tailnet.ts.net"' <<<"$output" >/dev/null
+}
+
+test_setup_rejects_a_non_proxy_root_without_mutation() {
+  # Arrange: An existing root text handler belongs to another Serve use.
+  write_online_status
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Text":"already used"}}}}}' >"$test_root/serve.json"
+  : >"$test_root/mutations.log"
+
+  # Act: Attempt bounded setup against the conflicting route.
+  if FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_TAILSCALE_AFTER_SETUP="$test_root/serve.json" FAKE_TAILSCALE_MUTATION_LOG="$test_root/mutations.log" \
+    bash "$test_root/tailscale-helper" setup >/dev/null 2>&1; then return 1; fi
+
+  # Assert: Conflict detection happens before the only mutating Tailscale command.
+  [ ! -s "$test_root/mutations.log" ]
+}
+
+test_inspect_falls_back_to_the_app_executable() {
+  local fallback_helper
+
+  # Arrange: The conventional wrapper is absent but the app executable is available.
+  write_online_status
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9417"}}}}}' >"$test_root/serve.json"
+  fallback_helper="$test_root/tailscale-fallback-helper"
+  sed -e "s|@TAILSCALE_WRAPPER@|$test_root/missing-tailscale|g" -e "s|@TAILSCALE_APP@|$test_root/tailscale|g" \
+    -e "s|@CURL@|$test_root/curl|g" -e "s|@JQ@|$(command -v jq)|g" \
+    -e "s|@GREP@|/usr/bin/grep|g" -e "s|@TR@|/usr/bin/tr|g" \
+    nix/modules/home/host-artifact-tailscale.sh >"$fallback_helper"
+
+  # Act: Inspect using the generated fallback selection.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" bash "$fallback_helper" inspect)"
+
+  # Assert: App-only installations retain the configured transport contract.
+  jq -e '.available and .configured' <<<"$output" >/dev/null
+}
+
+test_inspect_degrades_when_tailscale_is_offline() {
+  # Arrange: The CLI exists but reports an offline local node.
+  printf '%s\n' '{"Self":{"Online":false,"DNSName":""}}' >"$test_root/status.json"
+  printf '%s\n' '{}' >"$test_root/serve.json"
+
+  # Act: Inspect the unavailable transport.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" bash "$test_root/tailscale-helper" inspect)"
+
+  # Assert: Offline is valid local-degradation state, not an unsafe setup attempt.
+  jq -e '. == {schemaVersion:1,available:false,configured:false,reason:"tailscale-offline"}' <<<"$output" >/dev/null
+}
+
+test_setup_configures_only_an_empty_serve_root() {
+  # Arrange: Tailscale is online with no Serve config, and the fake exposes the post-setup state.
+  write_online_status
+  printf '%s\n' '{}' >"$test_root/serve.json"
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9417"}}}}}' >"$test_root/after.json"
+
+  # Act: Run the bounded setup operation.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_TAILSCALE_AFTER_SETUP="$test_root/after.json" bash "$test_root/tailscale-helper" setup)"
+
+  # Assert: Reinspection reports the configured stable origin.
+  jq -e '.available and .configured and .origin == "https://machine.tailnet.ts.net"' <<<"$output" >/dev/null
+}
+
+test_verify_constructs_the_only_remote_url_and_checks_revision() {
+  # Arrange: Serve is configured and curl returns the expected opaque revision header.
+  write_online_status
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9417"}}}}}' >"$test_root/serve.json"
+  revision="r-0123456789abcdef0123456789abcdef"
+
+  # Act: Verify a grammar-valid artifact identity without accepting a URL argument.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_CURL_REVISION="$revision" bash "$test_root/tailscale-helper" verify owner-repo~012345abcdef report "$revision")"
+
+  # Assert: The verified URL is constructed solely from authoritative state and validated slugs.
+  jq -e '.verified and .url == "https://machine.tailnet.ts.net/a/owner-repo~012345abcdef/report/"' <<<"$output" >/dev/null
+}
+
+test_verify_rejects_a_non_success_response_with_matching_revision() {
+  # Arrange: A redirect happens to echo the expected revision header.
+  write_online_status
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9417"}}}}}' >"$test_root/serve.json"
+  revision="r-0123456789abcdef0123456789abcdef"
+
+  # Act: Verify the artifact through a non-2xx remote response.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_CURL_REVISION="$revision" FAKE_CURL_STATUS=302 bash "$test_root/tailscale-helper" verify owner-repo~012345abcdef report "$revision")"
+
+  # Assert: A matching header cannot turn a non-success HTTP status into verification.
+  jq -e '. == {schemaVersion:1,verified:false,reason:"remote-verification-failed"}' <<<"$output" >/dev/null
+}
+
+test_workspace_resolve_normalizes_a_remote_repository() {
+  # Arrange: A repository has a conventional scp-like origin.
+  mkdir "$test_root/repository"
+  git -C "$test_root/repository" init -q
+  git -C "$test_root/repository" remote add origin git@GitHub.COM:nananaman/skills.git
+
+  # Act: Resolve identity from inside the repository.
+  output="$(cd "$test_root/repository" && bash "$test_root/workspace-helper" resolve)"
+
+  # Assert: The response exposes only a safe display name and deterministic segment.
+  jq -e '.schemaVersion == 1 and .status == "ok" and .workspace.displayName == "nananaman/skills"
+    and (.workspace.segment | test("^nananaman-skills~[a-f0-9]{12}$"))
+    and (keys == ["schemaVersion","status","workspace"])' <<<"$output" >/dev/null
+}
+
+test_workspace_resolve_ignores_hostile_global_git_config() {
+  # Arrange: The repository has a valid local origin while HOME contains malformed global config.
+  mkdir "$test_root/scoped-repository" "$test_root/hostile-home"
+  git -C "$test_root/scoped-repository" init -q
+  git -C "$test_root/scoped-repository" remote add origin git@github.com:nananaman/skills.git
+  printf '%s\n' '[broken' >"$test_root/hostile-home/.gitconfig"
+
+  # Act: Resolve identity with the hostile global config selected by HOME.
+  output="$(cd "$test_root/scoped-repository" && HOME="$test_root/hostile-home" bash "$test_root/workspace-helper" resolve)"
+
+  # Assert: Only repository-local origin participates in the canonical identity.
+  jq -e '.workspace.displayName == "nananaman/skills"
+    and (.workspace.segment | test("^nananaman-skills~[a-f0-9]{12}$"))' <<<"$output" >/dev/null
+}
+
+test_workspace_resolve_falls_back_for_a_local_remote() {
+  # Arrange: A local-path origin has no trustworthy host identity.
+  mkdir "$test_root/local-repository"
+  git -C "$test_root/local-repository" init -q
+  git -C "$test_root/local-repository" remote add origin ../upstream.git
+
+  # Act: Resolve the repository without interpreting the local path as a remote host.
+  output="$(cd "$test_root/local-repository" && bash "$test_root/workspace-helper" resolve)"
+
+  # Assert: The display remains a basename and no absolute path is emitted.
+  jq -e '.workspace.displayName == "local-repository"
+    and (.workspace.segment | test("^local-repository~[a-f0-9]{12}$"))' <<<"$output" >/dev/null
+  if grep -Fq "$test_root" <<<"$output"; then return 1; fi
+}
+
+test_workspace_resolve_keeps_linked_worktree_identity() {
+  # Arrange: A linked worktree shares common Git metadata and the same remote origin.
+  mkdir "$test_root/main"
+  git -C "$test_root/main" init -q
+  git -C "$test_root/main" remote add origin https://github.com/nananaman/skills.git
+  git -C "$test_root/main" -c user.name=test -c user.email=test@example.invalid commit --allow-empty -qm initial
+  git -C "$test_root/main" worktree add -q -b linked "$test_root/linked"
+
+  # Act: Resolve both working directories independently.
+  main_output="$(cd "$test_root/main" && bash "$test_root/workspace-helper" resolve)"
+  linked_output="$(cd "$test_root/linked" && bash "$test_root/workspace-helper" resolve)"
+
+  # Assert: Common remote identity produces the same workspace segment.
+  [ "$(jq -r '.workspace.segment' <<<"$main_output")" = "$(jq -r '.workspace.segment' <<<"$linked_output")" ]
+}
+
+render_helpers
+test_public_wrapper_prefers_command_policy_shims_for_every_operation
+test_inspect_reports_configured_serve_without_exposing_external_state
+test_inspect_rejects_conflicting_root_target
+test_inspect_fails_closed_when_serve_status_fails
+test_inspect_fails_closed_when_node_status_command_fails
+test_inspect_fails_closed_for_empty_online_dns_name
+test_setup_rejects_malformed_online_dns_name_without_mutation
+test_setup_does_not_mutate_when_serve_status_fails
+test_inspect_ignores_other_hosts_and_non_https_ports
+test_setup_rejects_a_non_proxy_root_without_mutation
+test_inspect_falls_back_to_the_app_executable
+test_inspect_degrades_when_tailscale_is_offline
+test_setup_configures_only_an_empty_serve_root
+test_verify_constructs_the_only_remote_url_and_checks_revision
+test_verify_rejects_a_non_success_response_with_matching_revision
+test_workspace_resolve_normalizes_a_remote_repository
+test_workspace_resolve_ignores_hostile_global_git_config
+test_workspace_resolve_falls_back_for_a_local_remote
+test_workspace_resolve_keeps_linked_worktree_identity

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -94,9 +94,9 @@ test_ensure_wrapper_requires_the_server_identity() {
   # Arrange: An unrelated process can occupy the fixed port and return HTTP 200.
   # Act: Inspect the readiness predicate used before and after kickstart.
   # Assert: Only the versioned host-artifact health document counts as healthy.
-  rg -q '\{"service":"host-artifact","version":1,"status":"ok"\}' "$packages_module"
+  rg -q '\{"service":"host-artifact","version":2,"status":"ok"\}' "$packages_module"
   rg -q 'is_expected_health "\$health_body"' "$packages_module"
-  rg -q '\{"service":"host-artifact","version":1,"status":"ok",'\''\*' "$packages_module"
+  rg -q '\{"service":"host-artifact","version":2,"status":"ok",'\''\*' "$packages_module"
 }
 
 test_profile_grants_only_the_publish_root_and_exact_ensure_command() {
@@ -199,14 +199,10 @@ test_launch_agent_runs_typescript_with_bun_through_nono() {
   rg -q 'host-artifact-server\.jsonc' "$dotfiles_module"
 }
 
-test_server_wrapper_refreshes_the_authoritative_tailscale_address() {
-  # Arrange: The fixed host wrapper runs before the server enters its nono sandbox.
-  # Act: Inspect how it discovers and passes the Tailscale listener address.
-  # Assert: Only the Tailscale CLI result becomes the server's authoritative candidate.
-  rg -Fq '/usr/local/bin/tailscale ip -4' "$packages_module" || return 1
-  rg -Fq 'while /bin/sleep 15' "$packages_module" || return 1
-  rg -Fq '.local/state/host-artifact/tailscale-address' "$packages_module" || return 1
-  rg -Fq -- '--tailscale-address-file "$tailscale_address_file"' "$packages_module" || return 1
+test_server_wrapper_has_no_tailscale_listener_state() {
+  # Arrange: Remote access is owned by Tailscale Serve outside the server process.
+  # Act & Assert: The server wrapper neither discovers an address nor passes listener state.
+  if rg -q 'tailscale_address|tailscale-address|tailscale ip' "$packages_module"; then return 1; fi
 }
 
 test_server_wrapper_recycles_stale_runtime_after_skill_update() {
@@ -218,17 +214,14 @@ test_server_wrapper_recycles_stale_runtime_after_skill_update() {
   rg -Fq 'kill -TERM "$server_pid"' "$packages_module" || return 1
 }
 
-test_server_profile_reads_only_the_protected_tailscale_address_state() {
+test_server_profile_has_no_tailscale_state_grant() {
   local profile_json
 
   # Arrange: Normalize the dedicated server profile.
   profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$server_profile")"
 
-  # Act & Assert: The server reads the exact state file without gaining state-directory write access.
-  jq -e '
-    .filesystem.read_file == ["@HOME@/.local/state/host-artifact/tailscale-address"]
-    and (.filesystem.bypass_protection | index("@HOME@/.local/state/host-artifact") == null)
-  ' <<<"$profile_json" >/dev/null || return 1
+  # Act & Assert: A loopback-only server needs no Tailscale state-file access.
+  jq -e '.filesystem | has("read_file") | not' <<<"$profile_json" >/dev/null || return 1
 }
 
 test_activation_installs_frozen_bun_dependencies_before_service_use() {
@@ -249,10 +242,10 @@ test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
   # Assert: The trusted wrapper runs only the installed CLI source with bounded public argv.
   rg -q 'writeShellScriptBin "host-artifact"' "$packages_module" || return 1
   rg -q 'src/cli\.ts' "$packages_module" || return 1
-  rg -q -- '--no-reload' "$packages_module" || return 1
+  if rg -q -- '--no-reload|--tailscale|host PATH|update ARTIFACT' "$packages_module"; then return 1; fi
   jq -e '
     .command_policies.commands["host-artifact"].can_use
-      == ["host-artifact-service"]
+      == ["host-artifact-service","host-artifact-tailscale","host-artifact-workspace"]
   ' <<<"$profile_json" >/dev/null
   jq -e '
     .command_policies.commands["host-artifact"].from.session.sandbox
@@ -273,8 +266,8 @@ test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
         "default":"deny",
         "allow":[
           {"argv":{"exact":["status"]}},
-          {"argv":{"prefix":["host"]}},
-          {"argv":{"prefix":["update"]}},
+          {"argv":{"exact":["setup"]}},
+          {"argv":{"prefix":["publish"]}},
           {"argv":{"prefix":["remove"]}}
         ]
       }
@@ -283,6 +276,79 @@ test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
     .command_policies.commands["host-artifact-service"]
       .from["host-artifact"].invocation_policy
       == {"default":"deny","allow":[{"argv":{"exact":["ensure"]}}]}
+  ' <<<"$profile_json" >/dev/null
+}
+
+test_agent_cli_grants_only_the_fixed_shlock_executable() {
+  local profile_json
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
+
+  # Arrange: The publisher acquires PID locks with direct execFile of the system shlock binary.
+  # Act: Inspect executable and filesystem capabilities of the main CLI child sandbox.
+  # Assert: Only the exact binary is added; lock/temp mutations remain under the existing publish root.
+  jq -e '
+    .command_policies.commands["host-artifact"].from.session.sandbox as $sandbox
+    | ($sandbox.fs_read_file | index("/usr/bin/shlock")) != null
+    and ($sandbox.unsafe_macos_seatbelt_rules | index("(allow process-exec (literal \"/usr/bin/shlock\"))")) != null
+    and $sandbox.fs_write == ["$HOME/.local/share/host-artifact/public"]
+    and ($sandbox.fs_read_file | index("/usr/bin") == null)
+  ' <<<"$profile_json" >/dev/null
+}
+
+test_tailscale_helper_exposes_only_bounded_operations() {
+  local profile_json
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
+
+  # Arrange: The helper owns all Tailscale and remote-network access.
+  # Act & Assert: Its caller policy accepts only inspect/setup and grammar-shaped verify.
+  rg -q 'writeShellScriptBin "host-artifact-tailscale"' "$packages_module" || return 1
+  rg -Fq '"/usr/local/bin/tailscale" "/Applications/Tailscale.app/Contents/MacOS/tailscale"' "$packages_module" || return 1
+  jq -e '
+    .command_policies.commands["host-artifact-tailscale"].from["host-artifact"].invocation_policy
+      == {"default":"deny","allow":[
+        {"argv":{"exact":["inspect"]}},
+        {"argv":{"exact":["setup"]}},
+        {"argv":{"prefix":["verify"]}}
+      ]}
+  ' <<<"$profile_json" >/dev/null
+  jq -e '
+    .command_policies.commands["host-artifact-tailscale"].from["host-artifact"].sandbox
+      .unsafe_macos_seatbelt_rules as $rules
+    | ($rules | index("(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))")) != null
+    and ($rules | index("(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spki\"))")) != null
+    and ($rules | index("(allow mach-lookup)")) == null
+  ' <<<"$profile_json" >/dev/null
+}
+
+test_workspace_helper_exposes_only_resolve_with_bounded_repository_read() {
+  local profile_json
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
+
+  # Arrange: Workspace identity may need linked-worktree common metadata under ghq.
+  # Act & Assert: Only resolve is callable and only workdir/ghq roots are readable.
+  rg -q 'writeShellScriptBin "host-artifact-workspace"' "$packages_module" || return 1
+  jq -e '
+    .command_policies.commands["host-artifact-workspace"].from["host-artifact"].invocation_policy
+      == {"default":"deny","allow":[{"argv":{"exact":["resolve"]}}]}
+    and (.command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.fs_read
+      == ["$WORKDIR","$HOME/ghq","/nix/store"])
+  ' <<<"$profile_json" >/dev/null
+}
+
+test_helper_command_sandboxes_strip_shell_startup_environment() {
+  local profile_json
+  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
+
+  # Arrange: Both trusted helpers start as Bash scripts before they validate public argv.
+  # Act: Inspect the environment inherited by each helper command sandbox.
+  # Assert: Attacker-controlled startup hook variables are removed before Bash starts.
+  jq -e '
+    ["HOME","WORKDIR","TMPDIR","PATH","LANG","LC_*"] as $safe
+    | .command_policies.commands["host-artifact-tailscale"].from["host-artifact"].sandbox.environment.allow_vars
+      == $safe
+    and .command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.environment.allow_vars
+      == $safe
+    and ($safe | index("BASH_ENV") == null and index("ENV") == null and index("*") == null)
   ' <<<"$profile_json" >/dev/null
 }
 
@@ -356,9 +422,15 @@ test_profile_grants_only_the_publish_root_and_exact_ensure_command
 test_ensure_command_sandbox_executes_only_its_fixed_dependencies
 test_server_profile_is_read_only_and_listens_only_on_the_service_port
 test_launch_agent_runs_typescript_with_bun_through_nono || exit 1
+test_server_wrapper_has_no_tailscale_listener_state || exit 1
 test_server_wrapper_recycles_stale_runtime_after_skill_update || exit 1
+test_server_profile_has_no_tailscale_state_grant || exit 1
 test_activation_installs_frozen_bun_dependencies_before_service_use || exit 1
 test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper || exit 1
+test_agent_cli_grants_only_the_fixed_shlock_executable || exit 1
+test_tailscale_helper_exposes_only_bounded_operations || exit 1
+test_workspace_helper_exposes_only_resolve_with_bounded_repository_read || exit 1
+test_helper_command_sandboxes_strip_shell_startup_environment || exit 1
 test_server_profile_reads_published_content_but_not_its_neighbor
 test_server_profile_cannot_write_published_content
 test_server_profile_cannot_replace_the_publish_root


### PR DESCRIPTION
## Summary
- host-artifact v2 の wrapper、helper、LaunchAgent readiness、sandbox policy を提供する
- Tailscale がない環境では localhost のまま利用でき、設定済み環境だけ Serve HTTPS を使う
- 旧 CLI・health protocol v1 との互換性は提供しない

## Changes
- public wrapper を v2 argv に限定し、nono shim 経由の helper dispatch を保証
- workspace identity helper と Tailscale inspect/setup/verify helper を追加
- Tailscale Serve の HTTPS 443、DNS、status、remote revision を fail-closed で検証
- helper 環境、Mach service、network、filesystem、`/usr/bin/shlock` の権限を限定
- service readiness を health protocol v2 に更新し、旧 listener/state updater を削除

## Tests
- `bash tests/host-artifact-helpers.sh`
- `bash tests/host-artifact-service.sh`
- changed shell scripts の `bash -n`
- `nix-instantiate --parse nix/modules/home/packages.nix`
- rendered nono profile validation
- `git diff --check`

## Review notes
- Review gate: `review-diff-code`、sandbox specialist review、blind adversarial review、Builder/Critic loop
- Target: `origin/main...084a67f`
- Result: actionable finding 0
- companion: https://github.com/nananaman/skills/pull/57
- companion skills PR と揃えて rollout する breaking change
- Home Manager activation、service restart、実 Tailscale mutationは未実施

<details>
<summary>Implementation plan</summary>

# host-artifact の閲覧体験を再設計する

## 目的

agent が生成したブラウザ向け静的成果物を、ユーザーが配信方式や artifact ID を管理せずに閲覧できるようにする。

HTML、SVG、画像、PDF、top-level に `index.html` を持つ静的 directory を生成した agent は、明示的な hosting 依頼を待たず、成果物の意味を表す短い名前で publish し、クリック可能な URL を返す。ブラウザは自動起動しない。同じ workspace の同じ名前への再 publish は同じ URL の新 revision となり、開いている HTML は live reload する。

通常経路では Tailscale の有無や公開 scope を質問しない。Tailscale Serve が設定済みなら MagicDNS FQDN の HTTPS URL を返し、Tailscale が未導入・停止中・未設定なら localhost URL を返す。artifact の path identity は transport にかかわらず `/a/<workspace>/<artifact>/` で共通にする。

## 現状

`productivity/host-artifact` は Bun で checked-in TypeScript を直接実行する CLI と Hono server からなる。`host` は入力を publish root にコピーし、推測困難な `local[-live]-<32hex>` または `tailscale[-live]-<32hex>` を発行する。`update` は agent がその ID と元の basename を保持している場合だけ単一 file を更新でき、directory は更新できない。`remove` は ID 指定、`status` は service health と Tailscale listener を返す。

server は loopback listener に加えて Tailscale IPv4 を検出・reconcile し、ID prefix により Tailscale listener から local artifact が見えないようにしている。CLI は localhost route の取得成功を publish 完了条件とし、`--tailscale` 指定時だけ Tailscale listener の bind と追加 URL を確認する。単一 HTML file には配信用 copy だけへ polling script を注入し、ETag と source-version header によって同じ URL を reload する。

この構造では公開 scope が artifact identity に埋め込まれ、作成時の選択、長い ID の引き回し、file と directory で異なる更新体験が必要になる。root route は listing を意図的に返さず、過去の artifact を再発見する入口もない。

runtime service の起動は repository 外の `/Users/juntawatanabe/ghq/github.com/nananaman/dotfiles` が提供する `host-artifact-service ensure`、LaunchAgent、nono profile に依存する。同 repository の wrapper は旧 CLI command だけを許可し、health protocol version 1、独自 Tailscale address updater、server の Tailscale state file 読み取りを固定している。この repository は server entrypoint と package metadata を持つが、現行の deployment contract を合わせて変更しなければ新 CLI は sandbox から利用できない。

dotfiles の server wrapper は installed skill の `src`、`package.json`、`bun.lock` の fingerprint 変化を検出して server child を終了し、LaunchAgent の KeepAlive で新 runtime を起動する。Home Manager activation も runtime 準備後に対象 LaunchAgent を kickstart する。breaking rollout ではこの既存機構を使い、health protocol を version 2 に上げて旧 daemon を ready とみなさない。

現在確認した端末には Tailscale 1.98.9 と MagicDNS FQDN があるが、Tailscale Serve の設定はない。実装はこの端末状態を前提にせず、Tailscale command または dotfiles helper の不在を通常の local transport として扱う。

関連する agent-facing contract は `productivity/host-artifact/SKILL.md` のほか、`engineering/implement/SKILL.md` と `engineering/explain-diff/SKILL.md` に旧 `host` / `update` / opt-in hosting の記述がある。root と productivity の README も localhost / Tailscale の選択を前提にしている。

互換性は要求しない。旧 ID route、旧 CLI command、旧 response schema は新実装から削除する。publish root に残る既存 artifact data は自動移行も削除もせず、新 server と shelf から不可視にする。

## 設計方針

### CLI と agent contract

通常の書き込み interface を次に一本化する。

```text
host-artifact publish <path> --name <artifact-name>
```

`publish` は cwd から workspace identity を自動決定し、入力を検証して revision を保存し、service を ensure し、exact route を localhost で検証して JSON を返す。JSON は少なくとも schema version、workspace、name、revision、URL、transport (`tailscale-serve` または `localhost`)、content kind、updated time を持つ。agent は URL と、remote 閲覧ができない場合に限って local-only 状態をユーザーへ短く伝える。ブラウザを開く処理は持たない。

artifact 名は agent が成果物の意味から明示する。入力は変換せず、1〜64文字で `^(?!.*--)[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$` に一致する canonical slug だけを受け入れる。大文字、空白、underscore、連続 hyphen を含む値、先頭・末尾が hyphen の値、percent encoding、Unicode、path separator、dot segment は拒否する。artifact route 内に予約名は設けない。別案を並存させる場合は別名で publish する。同一 key への publish は file 名や file/directory の違いにかかわらず新 revision として置換する。

workspace identity は権限制限済み `host-artifact-workspace resolve` helper に cwd を暗黙入力として問い合わせる。helper は git repository 内なら Git の common metadata を辿り、`remote.origin` を URI または scp-like Git URL として parse する。canonical key は lowercase host、`/` 区切りの remote path、除去済みの末尾 `/` と `.git` から作る。host を持たない local remote は一意な remote とみなさず fallback にする。remote を一意に解釈できない directory では `realpath(cwd)` を canonical key にする。

workspace URL segment は、canonical key から得る表示 prefix と digest を `<prefix>~<digest>` で結合する。prefix は owner/repository、fallback では cwd basename を lowercase ASCII 化し、最大連続の `[a-z0-9]` 以外を `-` へ置換し、先頭末尾の `-` を除去して48文字で切り、切った末尾の `-` も除去する。空なら `workspace` とする。digest は canonical key の UTF-8 bytes に対する SHA-256 の先頭12 lowercase hex とする。segment は `^[a-z0-9][a-z0-9-]{0,47}~[a-f0-9]{12}$` に一致し、digest により slug 化や delimiter の曖昧さによる衝突を避ける。shelf の表示名は secret を含まない owner/repository または basename だけとする。

absolute path、raw remote URL、canonical key は helper response の表示 field、artifact metadata、URL、shelf に露出させない。linked worktree は common Git metadata の同じ origin から同じ workspace identity を得る。workspace helper response の parser と workspace segment の canonical fixture を skills/dotfiles の両 repository で検証する。helper 不在または malformed response は、勝手に別 workspace を作らず publish 前に環境 contract error として停止する。

明示削除は名前ベースにする。

```text
host-artifact remove --name <artifact-name>
```

cwd から同じ workspace を解決し、その artifact だけを削除する。`status` は service health、選択された transport、local origin、設定済みなら remote origin を返す。旧 `host`、ID 指定 `update`、scope flag、`--no-reload` は提供しない。HTML の live reload は標準動作とし、byte-for-byte 配信を必要とする成果物は今回の artifact 対象外とする。

`SKILL.md` は「ブラウザで自然に確認する静的成果物を生成したとき」を positive routing、「機密情報を含む、dynamic application、public Internet 公開、byte-for-byte snapshot」を negative routing とする。対象形式なら agent が自動で `publish --name` を使い、URL を返す outcome-based contract に改める。`engineering/implement` と `engineering/explain-diff` の opt-in hosting、ID 保持、Tailscale 選択の記述も同じ contract に更新し、README の一覧と導線を合わせる。

### 保存モデルと publish transaction

publish root の新 namespace に workspace/artifact ごとの metadata と immutable revision を保存する。revision ID は CSPRNG の16 bytesを lowercase hex にした `r-<32hex>`、grammar は `^r-[a-f0-9]{32}$` とする。旧 ID directory と名前が衝突せず、旧 data を列挙しない layout にする。

各 publish は次の状態遷移を満たす。

1. service を ensure し、local health を確認してから publish transaction を始める。
2. source tree を検証し、同じ artifact 配下の一意な staging revision へコピーする。
3. HTML file または directory の entry `index.html` には配信用 copy にだけ live-reload script を注入する。元 source は変更しない。
4. 完成した revision の opaque な一意 ID、kind、entry、更新時刻を含む metadata を検証する。
5. previous `current` metadata を保持したまま、新しい `current` を同一 filesystem 上の temporary file から atomic rename し、新 revision を可視化する。
6. exact localhost artifact-root route を GET し、2xx に加えて response の revision header が期待する revision ID と一致するまで bounded retry する。
7. local 検証に失敗した場合、previous `current` があれば temporary file と atomic rename で復元し、初回 publish なら新しい `current` を除去する。rollback 後に未確立 revision だけを cleanup する。rollback または cleanup も失敗した場合は primary error と全 cleanup error を返す。
8. 成功後も旧 revision は削除しない。HTTP route と shelf は `current` が指す revision だけを参照し、旧 revision は不可視のまま保持する。明示的な `remove` はその artifact の全 revision を削除する。

同じ key への publish と remove は同じ artifact lock で直列化し、結果は lock 取得順に確定する。publish の後に lock を得た remove は全 revision を削除し、remove の後に lock を得た publish は新しい artifact を作る。last-writer-wins を偶然の rename 順に依存させない。lock の取得は bounded とし、stale lock を所有確認なしに削除しない。実装時には state と filesystem operation を分離し、成功・rollback・cleanup failure と publish/remove race を fake dependency で検証できるようにする。

入力の symlink、dotfile、特殊 file は現行どおり拒否する。directory は通常 file の top-level `index.html` を必須とする。単一 file は HTML、SVG、PDF、およびブラウザ表示可能な既定の画像形式（PNG、JPEG、GIF、WebP、AVIF）だけを受け入れ、extension と配信 MIME の対応を明示的な allowlist としてテストする。directory 内 asset は現在と同様に MIME 判定して配信する。

### HTTP route、live reload、shelf

server は `127.0.0.1` のみに bind し、Tailscale IPv4 listener、listener reconciler、scope filtering を削除する。Tailscale 経由の公開は reverse proxy の責務とする。

`GET /a/:workspace/:artifact/` は current metadata が指す entry を返す。directory asset は `GET /a/:workspace/:artifact/*` で同じ immutable revision 内だけから解決する。workspace、artifact、asset の decode、dot segment、dotfile、symlink、realpath containment、通常 file の検査を維持し、metadata と revision 管理 file は route から取得できないようにする。旧 `/<capability-id>/<path>` route は提供しない。

GET/HEAD の ETag、`If-None-Match` の 304、`Cache-Control: no-store`、`X-Content-Type-Options: nosniff` は維持する。全 kind の artifact root と asset response は current metadata の opaque revision ID を `X-Host-Artifact-Revision` で返す。localhost/remote の publish verification は artifact-root response のこの header を期待値と比較し、単なる 2xx を成功扱いしない。ETag は従来どおり個々の response body から算出し、registry-level content hash は持たない。HTML entry の live reload は artifact root URL への HEAD で displayed revision header を比較し、revision が変わったときだけ reload して scroll 位置を復元する。directory artifact の entry HTML にも同じ仕組みを適用する。画像、SVG、PDF は自動 reload を約束しない。

`GET /` は server-side で生成した shelf HTML を返す。新 namespace の valid な current metadata だけを読み、更新時刻の降順で workspace、artifact 表示名、kind、更新時刻、artifact link を表示する。壊れた・staging 中・旧形式の entry は表示せず、個別の corrupt metadata が shelf 全体を 500 にしない。shelf は閲覧専用とし、削除・編集・directory listing API は追加しない。HTML escape、URL encode、空状態、複数 workspace、同時 publish 中の表示をテストする。

### transport detection と一度限りの setup

通常の `publish` は Tailscale 設定を変更しない。local exact route の検証に成功した後、Tailscale command と状態を read-only で調べる。

- command がない、node が offline、MagicDNS FQDN が得られない、または Serve がこの service を proxy していない場合は `http://127.0.0.1:9417/a/...` と `transport: localhost` を返す。
- Serve status が HTTPS root を `http://127.0.0.1:9417` へ proxy していることを確認できる場合だけ、末尾の dot を除いた Self DNSName を使う HTTPS URL と `transport: tailscale-serve` を返す。
- remote URL の検証は通常 CLI から任意 network access を行わず、`host-artifact-tailscale verify <workspace> <artifact> <revision>` helper に委譲する。helper は各引数を canonical grammar で再検証し、authoritative な Self DNSName と既存 Serve config から自分で artifact-root HTTPS URL を構成する。その URL だけを bounded retry で取得し、2xx と期待する `X-Host-Artifact-Revision` の両方を確認して、検証済み URL を返す。失敗時は publish 自体を rollback せず localhost response と到達不能理由へ degrade する。

transport は後述する権限制限済み `host-artifact-tailscale inspect` / `verify` helper の JSON を adapter から読み、pure parser と分離する。helper 不在、Tailscale 非導入、offline、不正 JSON、unconfigured、別 target との conflict、configured、remote verification failure を fixture/fake で検証する。通常 CLI の sandbox は localhost:9417 以外の network access を得ない。IP address、interface scan、独自 remote listener は削除する。

Tailscale 利用者向けに、ユーザーが一度だけ明示実行する command を用意する。

```text
host-artifact setup
```

`setup` は service を ensure した後、権限制限済み `host-artifact-tailscale setup` helper に委譲する。helper は Tailscale と online/MagicDNS を確認し、既存 Serve 設定が同じ loopback target なら idempotent success とする。root に別 target があるなど安全に merge できない場合は変更せず conflict を返す。設定が空で安全な場合だけ、現在の Tailscale CLI が提供する background HTTPS Serve で `http://127.0.0.1:9417` を公開し、Serve status と remote health endpoint を helper 内で再取得して、その時点の FQDN を返す。FQDN は永続保存せず、`publish` と `status` も authoritative な helper result から毎回導出する。helper または Tailscale command 不在時は失敗ではなく「setup 不要、localhost mode」と報告する。interactive login、MagicDNS/HTTPS の tailnet admin 設定、既存 Serve route の reset、Funnel/public Internet 公開は自動実行しない。

実装では `tailscale serve --help` と公式 CLI contract に沿う引数を採用し、実機の既存 Serve 設定を変更する automated end-to-end test は行わない。skills 側は helper adapter を fake process runner で検証し、dotfiles 側は fixture 化した Tailscale output と fake executable で inspect、command 不在、conflict、setup、idempotency を検証する。手動確認手順として未設定端末での conflict-free setup、HTTPS URL、再実行の idempotency を記載する。

### dotfiles companion change と rollout

`/Users/juntawatanabe/ghq/github.com/nananaman/dotfiles` では、既存の declarative service boundary を次のように更新する。

- `host-artifact` wrapper の public argv を `publish PATH --name NAME`、`remove --name NAME`、`status`、`setup` に置換し、旧 command/flag を拒否する。nono invocation policy も同じ allowlist にする。
- health document と `host-artifact-service ensure` の readiness predicate を protocol version 2 に更新する。bounded restart/readiness polling は service wrapper だけが所有する。skills 側 CLI は version 2 だけを ready とみなし、旧 daemon 検出時は `ensure` を一度呼び、正常終了後に protocol version 2 health を一度だけ再確認する。不一致なら publish transaction を開始せず runtime rollout mismatch として停止する。
- `host-artifact-server` から Tailscale address updater、state file、`--tailscale-address-file` argument を削除する。server profile から同 state file の read grant を削除し、loopback port 9417 の listen と publish root の read-only access は維持する。
- Tailscale 操作専用の trusted wrapper `host-artifact-tailscale` を追加し、public operation を引数なしの `inspect` / `setup` と、grammar 検証済み3引数を取る `verify` に制限する。`inspect` は `tailscale status --json` と `tailscale serve status --json` から必要な状態だけを schema-versioned JSON で返す。`setup` は空または同一 target の Serve config だけを受け入れ、空の場合だけ固定 target `http://127.0.0.1:9417` を HTTPS/background mode で設定して再検証する。`verify` は helper が構成した Self DNSName の HTTPS artifact-root だけを取得する。任意 URL/target、Funnel、reset、login、ほかの Tailscale subcommand を受け取らない。
- workspace identity 専用の trusted wrapper `host-artifact-workspace` を追加し、cwd を暗黙入力とする引数なしの `resolve` だけを提供する。固定 Git executable を使い、helper の sandbox だけに `$WORKDIR` と ghq-managed repository root `$HOME/ghq` の read access を与える。dynamic path grant は導入しない。この bounded broader root により linked worktree の common Git metadata を読めるようにし、固定 helper は上記 canonical workspace segment と安全な表示名以外を返さない。raw remote URL、absolute path、canonical key、Git config 内容は返さない。linked worktree、通常 repository、ghq 外の non-Git directory、malformed remote を fixture と sandbox integration で検証する。
- `host-artifact` command policy の `can_use` に上記2 helper を追加し、helper policy は `host-artifact` caller からの exact/pattern-validated operation だけを許可する。Tailscale helper には `/usr/local/bin/tailscale`、固定 `/usr/bin/curl`、Tailscale local API、helper 自身が構成する remote HTTPS のための port 443 outbound を与える。sandbox の port 443 grant は destination を静的に限定できないため、wrapper が任意 URL を入力として受け取らないことを safety boundary とし、policy test と wrapper test の両方で固定する。workspace helper には固定 Git executableと repository/common metadata の readだけを与える。session から両 helperを直接任意引数で呼べず、通常 CLI は localhost-only network のままであることを test する。
- `tests/host-artifact-service.sh`、`tests/nono-profile.sh`、関連 Nix module tests を新 protocol、argv、最小 filesystem/network/process permission、runtime restart contract に合わせる。

互換 layer を置かないため、deployment は両 repository の変更を揃えた maintenance operation とする。dotfiles の `apm/apm.yml` は現在 `~/ghq/github.com/nananaman/skills/productivity/host-artifact` への local path dependency なので、この model を維持し、remote SHA pin への migration や manifest 編集は行わない。

forward deployment は、まず両 repository の開始 SHA と clean status を記録し、ユーザーの明示依頼を得て skills 実装と dotfiles companion change をそれぞれ commit する。skills checkout が新 commit を指し、dotfiles checkout が対応 commit を指す状態で、dotfiles から `apm install -g`、Home Manager activation の順に適用する。activation は dependencies を準備して LaunchAgent を強制再起動し、最後に health version 2、localhost shelf、read-only transport status を確認する。適用中は旧/new wrapper と runtime の混在を正常利用可能とはみなさず、artifact command を実行しない。

途中失敗時は追加 publish/setup を止める。rollback はユーザーの明示承認を得て両 repository の実装 commit を `git revert` し、local path が revert 後の skills checkout を指す状態で `apm install -g`、Home Manager activation を再実行する。開始時 SHA と revert commit を記録し、health version 1 と旧 status が戻ったことを確認する。既存 artifact data は rollback でも削除しない。未 commit worktree や detached/異なる skills revision を rollout source にせず、revert 以外の checkout/reset でユーザー変更を上書きしない。

### 変更対象と検証

skills repository の主な変更対象は `productivity/host-artifact/src/{config,cli-lib,cli,publisher,app,server-main,live-reload}.ts` とその tests である。不要になる `listeners.ts`、`tailscale.ts` と対応 tests は削除する。workspace/slug、registry metadata、transport/helper parsing の責務は既存 file に押し込まず、小さな module と focused test に分ける。`package.json` と runtime-contract test は Bun/checked-in TypeScript/no generated JS の契約を維持する。dotfiles repository の変更対象は上記 companion section の Nix wrappers、LaunchAgent module、nono profiles、shell tests である。

実装は repository 規約どおり探索後に Red → Green → Refactoring で進め、追加・変更する test は Arrange / Act / Assert を明記し、異常系を正常系と別 test function にする。少なくとも次を検証する。

- `bun test`: name/workspace helper response と identity、許可形式、file/directory の初回 publish と同一 URL 更新、atomic current 切替、並行 publish/remove と ordering、rollback/cleanup failure、remove の containment、shelf、route security、ETag/HEAD/304、file と directory HTML の live reload、health protocol v2、transport/setup/remote verification helper orchestration、CLI JSON contract。
- `bun run typecheck`: strict TypeScript contract。
- `python3 scripts/check-skill-inventory.py` と `python3 -m unittest tests/test_check_skill_inventory.py`: frontmatter、README 導線、relative link、inventory。
- local integration: isolated temporary publish root と port で server を起動し、publish response の localhost exact route、shelf、再 publish 後の revision header を curl で確認する。
- Tailscale 導入済み環境の read-only smoke check: `status` が現在の未設定状態を localhost と判定すること。`setup` による実設定変更はユーザーの明示実行に残す。
- dotfiles repository の既存 test entrypoint で wrapper argv、health v2/restart、Tailscale/workspace helper の固定 operation、通常/linked worktree の identity、remote verification、nono の最小 filesystem/process/network 権限、Tailscale address updater/state grant の除去を検証する。

主要 workflow と skill responsibility を変更するため、実装後は `skill-workbench` の Review whole を行い、accepted finding を解消した後に Review diff で regression を確認する。

## 完了条件

- 対象成果物を生成した agent が公開範囲や hosting の要否を質問せず、`publish --name` の一回で検証済み URL を返せる。
- 同じ workspace/name の file または directory を再 publish すると URL が変わらず、切替と並行する request を含め、読者には完成した旧 revision または完成した新 revision のどちらかだけが見える。旧 revision は自動削除されず、明示的な artifact 削除でまとめて削除される。
- HTML file と directory entry は同じ URL で live reload し、元 source は変更されない。
- Tailscale Serve が正しく設定済みなら検証済み HTTPS URLを返し、それ以外の環境では設定変更や失敗を起こさず検証済み localhost URLへ自動 degrade する。
- `setup` は同一設定に対して idempotent で、競合する Serve 設定、tailnet admin 操作、Funnel を変更しない。
- health protocol v2 と coordinated rollout により、旧 daemon を新 CLI の ready service と誤認せず、適用完了後は wrapper、server、nono policy が同じ contract で動く。
- shelf から valid な最近の artifact を再発見でき、旧 artifact、staging、破損 metadata、管理 file、source path は露出しない。
- 旧 CLI と旧 capability route は利用不能で、旧保存 data は削除されず新 shelf にも出ない。
- symlink、dotfile、特殊 file、path traversal、publish root identity change に対する既存の安全境界を維持する。
- package tests、typecheck、inventory tests、isolated local integration が成功する。
- `skill-workbench` Review whole と続く Review diff に actionable finding が残らない。

## スコープ外

- public Internet または LAN への公開、Tailscale Funnel。
- Tailscale の導入、login、tailnet の MagicDNS/HTTPS 有効化、ACL 変更。
- Tailscale 以外の remote transport、自動トンネル、cloud hosting。
- Markdown や source code の専用 viewer、dynamic application、server-side execution。
- browser の自動起動、会話 UI 内への iframe/embed。
- shelf からの編集・削除、全文検索、tag、revision history UI。
- 自動 expiry、容量 quota、旧 revision の GC、既存 artifact data の移行または削除。
- 旧 command、旧 response、旧 URL の互換 layer。

</details>
