### PR TITLE
fix(nono): Chrome bridgeとhost-artifact helperを許可する

### DIFF
--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -13,7 +13,9 @@
     "(allow file-read-metadata (literal \"/\"))",
     "(allow file-read-data (literal \"/Users\"))",
     "(allow file-read-data (literal \"@HOME@\"))",
-    "(allow network-outbound (path \"@HOME@/ghq/github.com/nananaman/dotfiles/herdr/herdr.sock\"))"
+    "(allow network-outbound (path \"@HOME@/ghq/github.com/nananaman/dotfiles/herdr/herdr.sock\"))",
+    // Chrome bridgeは起動ごとに生成されるnative host socketで通信する。
+    "(allow network-outbound (subpath \"/private/tmp/codex-browser-use\"))"
   ],
   "groups": {
     "include": [

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -195,9 +195,11 @@
           "host-artifact": {
             "sandbox": {
               "environment": { "allow_vars": ["HOME", "WORKDIR", "TMPDIR", "PATH", "LANG", "LC_*"] },
-              "fs_read": ["/nix/store"],
+              "fs_read": ["/nix/store", "/Applications/Tailscale.app"],
               "fs_read_file": [
+                "$WORKDIR",
                 "/bin/sh",
+                "/bin/bash",
                 "/usr/local/bin/tailscale",
                 "/Applications/Tailscale.app/Contents/MacOS/tailscale",
                 "/usr/bin/curl",
@@ -207,6 +209,7 @@
               "unsafe_macos_seatbelt_rules": [
                 "(allow process-exec (subpath \"/nix/store\"))",
                 "(allow process-exec (literal \"/bin/sh\"))",
+                "(allow process-exec (literal \"/bin/bash\"))",
                 "(allow process-exec (literal \"/usr/local/bin/tailscale\"))",
                 "(allow process-exec (literal \"/Applications/Tailscale.app/Contents/MacOS/tailscale\"))",
                 "(allow process-exec (literal \"/usr/bin/curl\"))",
@@ -236,11 +239,12 @@
             "sandbox": {
               "environment": { "allow_vars": ["HOME", "WORKDIR", "TMPDIR", "PATH", "LANG", "LC_*"] },
               "fs_read": ["$WORKDIR", "$HOME/ghq", "/nix/store"],
-              "fs_read_file": ["/usr/bin/git", "/usr/bin/shasum", "/usr/bin/sed", "/usr/bin/tr", "/usr/bin/cut"],
+              "fs_read_file": ["/usr/bin/git", "/usr/bin/shasum", "/usr/bin/perl", "/usr/bin/sed", "/usr/bin/tr", "/usr/bin/cut"],
               "unsafe_macos_seatbelt_rules": [
                 "(allow process-exec (subpath \"/nix/store\"))",
                 "(allow process-exec (literal \"/usr/bin/git\"))",
                 "(allow process-exec (literal \"/usr/bin/shasum\"))",
+                "(allow process-exec (literal \"/usr/bin/perl\"))",
                 "(allow process-exec (literal \"/usr/bin/sed\"))",
                 "(allow process-exec (literal \"/usr/bin/tr\"))",
                 "(allow process-exec (literal \"/usr/bin/cut\"))"

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -312,9 +312,13 @@ test_tailscale_helper_exposes_only_bounded_operations() {
       ]}
   ' <<<"$profile_json" >/dev/null
   jq -e '
-    .command_policies.commands["host-artifact-tailscale"].from["host-artifact"].sandbox
-      .unsafe_macos_seatbelt_rules as $rules
-    | ($rules | index("(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))")) != null
+    .command_policies.commands["host-artifact-tailscale"].from["host-artifact"].sandbox as $sandbox
+    | $sandbox.unsafe_macos_seatbelt_rules as $rules
+    | $sandbox.fs_read == ["/nix/store","/Applications/Tailscale.app"]
+    and ($sandbox.fs_read_file | index("$WORKDIR") != null)
+    and ($sandbox.fs_read_file | index("/bin/bash") != null)
+    and ($rules | index("(allow process-exec (literal \"/bin/bash\"))") != null)
+    and ($rules | index("(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))")) != null
     and ($rules | index("(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spki\"))")) != null
     and ($rules | index("(allow mach-lookup)")) == null
   ' <<<"$profile_json" >/dev/null
@@ -325,13 +329,17 @@ test_workspace_helper_exposes_only_resolve_with_bounded_repository_read() {
   profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
 
   # Arrange: Workspace identity may need linked-worktree common metadata under ghq.
-  # Act & Assert: Only resolve is callable and only workdir/ghq roots are readable.
+  # Act & Assert: Only resolve is callable, repository roots are readable, and shasum's fixed interpreter is executable.
   rg -q 'writeShellScriptBin "host-artifact-workspace"' "$packages_module" || return 1
   jq -e '
     .command_policies.commands["host-artifact-workspace"].from["host-artifact"].invocation_policy
       == {"default":"deny","allow":[{"argv":{"exact":["resolve"]}}]}
     and (.command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.fs_read
       == ["$WORKDIR","$HOME/ghq","/nix/store"])
+    and (.command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.fs_read_file
+      | index("/usr/bin/perl") != null)
+    and (.command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.unsafe_macos_seatbelt_rules
+      | index("(allow process-exec (literal \"/usr/bin/perl\"))") != null)
   ' <<<"$profile_json" >/dev/null
 }
 

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -221,6 +221,28 @@ test_common_profile_keeps_sensitive_data_denied_by_group() {
   done
 }
 
+test_common_profile_keeps_chrome_data_outside_direct_agent_access() {
+  # Arrange: Chrome bridge traffic uses its socket and does not require direct browser-data reads.
+  # Act & Assert: No local agent receives a Chrome user-data read or protection bypass.
+  assert_profile_value \
+    '.platform_overrides.macos.filesystem.read | map(select(contains("Google/Chrome"))) | length' \
+    '0'
+  assert_profile_value \
+    '(.platform_overrides.macos.filesystem.bypass_protection // []) | map(select(contains("Google/Chrome"))) | length' \
+    '0'
+}
+
+test_common_profile_allows_only_the_chrome_bridge_socket_subtree() {
+  # Arrange: Chrome bridge socket names are generated beneath one canonical macOS directory.
+  # Act & Assert: All local agents may connect only within that browser bridge subtree.
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("codex-browser-use"))] | tojson' \
+    '["(allow network-outbound (subpath \"/private/tmp/codex-browser-use\"))"]'
+  assert_profile_value \
+    '.platform_overrides.macos.filesystem | has("unix_socket_subtree")' \
+    'false'
+}
+
 test_common_profile_uses_enterprise_network() {
   assert_profile_value \
     '.network.network_profile' \
@@ -406,6 +428,8 @@ test_github_cli_uses_the_parent_sandbox
 test_ssh_private_key_remains_unreadable
 test_common_profile_includes_general_development_groups
 test_common_profile_keeps_sensitive_data_denied_by_group
+test_common_profile_keeps_chrome_data_outside_direct_agent_access
+test_common_profile_allows_only_the_chrome_bridge_socket_subtree
 test_common_profile_uses_enterprise_network
 test_common_profile_allows_development_endpoints
 test_common_profile_denies_unconfigured_clouds


### PR DESCRIPTION
## Summary

- nono内のlocal agentからChrome extension bridgeへ接続できるようにする
- Codex tool-sandboxから`host-artifact`の正規CLIと固定helperを最小権限で利用できるようにする
- ChromeのCookiesやHistory、host-artifact helperからのworkspace内容readは拒否したまま維持する

## Changes

- macOS Seatbeltで`/private/tmp/codex-browser-use`配下への`network-outbound`だけを共通agent profileに許可
- Tailscale CLI wrapperが実際に必要とする`/bin/bash`、Tailscale app bundleのread、固定binary execを許可
- Tailscale helperにはworkspace全体を許可せず、child起動時のcwd entryだけをliteral readとして許可
- workspace helperで`/usr/bin/shasum`の固定interpreterである`/usr/bin/perl`を許可
- Chrome dataのread拒否とhost-artifact helperのcommand/path境界をtestで固定

## Tests

- `nono profile validate --strict nono/profiles/chouge-codex.jsonc`
- `nono profile validate --strict nono/profiles/chouge-claude.jsonc`
- `nono profile validate --strict nono/profiles/chouge-pi.jsonc`
- `bash tests/host-artifact-service.sh`
- `bash tests/host-artifact-helpers.sh`
- `git diff --check`
- `nix run .#build`
- nonoの通常sessionからChrome extensionへ接続し、localhost tabのURL、title、DOM本文を読み取り
- `nono why --self`でChrome Cookiesのdirect readが`deny_browser_data_macos`により拒否されることを確認
- 再起動後のCodex tool-sandbox shimから`host-artifact publish ... --name tailscale-smoke`を直接実行
- 同じTailscale HTTPS URLのrevision更新とChrome上のlive reloadを確認
- source profileを使うfresh `nono run`で、workspace recursive readなしに`host-artifact status`が成功することを確認

## Review notes

- `review-diff-code`でChrome bridge差分を独立・adversarial review済み（findingなし）
- host-artifact差分をSandbox Policy Boundary reviewerとblind adversarial reviewerでreview
- workspace全体readが過大というfindingを採用し、cwd entryのliteral readへ縮小してfresh runtimeで再検証
- Tailscale remote verificationはmacOS system curlのpreference access拒否によりlocalhostへdegradeする既知制限が残るが、publish、Tailscale HTTPS配信、live reloadは成功
