### PR TITLE
fix(host-artifact): 親sandboxでの配信を安定化する

### DIFF
--- a/nix/modules/home/host-artifact-tailscale.sh
+++ b/nix/modules/home/host-artifact-tailscale.sh
@@ -83,8 +83,19 @@ case "${1:-}" in
     url="$origin/a/$workspace/$artifact/"
     response="$($curl_bin --silent --show-error --max-time 3 --retry 2 --head \
       --write-out 'Host-Artifact-Status: %{http_code}\n' "$url" 2>/dev/null || true)"
+    revision_header_matches() {
+      shopt -s nocasematch
+      while IFS= read -r header_line; do
+        case "$header_line" in
+          X-Host-Artifact-Revision:\ *)
+            [ "${header_line#*: }" = "$revision" ] && return 0
+            ;;
+        esac
+      done
+      return 1
+    }
     if printf '%s\n' "$response" | "$tr_bin" -d '\r' | "$grep_bin" -Eq '^Host-Artifact-Status: 2[0-9][0-9]$' && \
-      printf '%s\n' "$response" | "$tr_bin" -d '\r' | "$grep_bin" -Fqx "X-Host-Artifact-Revision: $revision"; then
+      revision_header_matches <<<"$(printf '%s\n' "$response" | "$tr_bin" -d '\r')"; then
       "$jq_bin" -cn --arg url "$url" '{schemaVersion:1,verified:true,url:$url}'
     else
       "$jq_bin" -cn '{schemaVersion:1,verified:false,reason:"remote-verification-failed"}'

--- a/nix/modules/home/host-artifact.sh
+++ b/nix/modules/home/host-artifact.sh
@@ -25,22 +25,7 @@ case "${1:-}" in
     ;;
 esac
 
-shim_dir="${NONO_TOOL_SANDBOX_SHIM_DIR:-}"
-case "$shim_dir" in
-  /*) ;;
-  *) echo "host-artifact: command-policy shim directory is unavailable" >&2; exit 69 ;;
-esac
-if [ ! -d "$shim_dir" ]; then
-  echo "host-artifact: command-policy shim directory is unavailable" >&2
-  exit 69
-fi
-for helper in host-artifact-service host-artifact-tailscale host-artifact-workspace; do
-  if [ ! -x "$shim_dir/$helper" ]; then
-    echo "host-artifact: required command-policy shim is unavailable: $helper" >&2
-    exit 69
-  fi
-done
-PATH="$shim_dir:$PATH"
+PATH="@HELPER_PATH@:$PATH"
 export PATH
 
 exec @BUN@ @CLI@ "$@"

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -221,15 +221,30 @@ let
 
   host-artifact = pkgs.writeShellScriptBin "host-artifact" (
     builtins.replaceStrings
-      [ "@BUN@" "@CLI@" ]
-      [ "${pkgs.bun}/bin/bun" "$HOME/.agents/skills/host-artifact/src/cli.ts" ]
+      [ "@BUN@" "@CLI@" "@HELPER_PATH@" ]
+      [
+        "${pkgs.bun}/bin/bun"
+        "$HOME/.agents/skills/host-artifact/src/cli.ts"
+        (pkgs.lib.makeBinPath [
+          host-artifact-service
+          host-artifact-tailscale
+          host-artifact-workspace
+        ])
+      ]
       (builtins.readFile ./host-artifact.sh)
   );
 
   host-artifact-tailscale = pkgs.writeShellScriptBin "host-artifact-tailscale" (
     builtins.replaceStrings
       [ "@TAILSCALE_WRAPPER@" "@TAILSCALE_APP@" "@CURL@" "@JQ@" "@GREP@" "@TR@" ]
-      [ "/usr/local/bin/tailscale" "/Applications/Tailscale.app/Contents/MacOS/tailscale" "/usr/bin/curl" "${pkgs.jq}/bin/jq" "/usr/bin/grep" "/usr/bin/tr" ]
+      [
+        "/usr/local/bin/tailscale"
+        "/Applications/Tailscale.app/Contents/MacOS/tailscale"
+        "/usr/bin/curl"
+        "${pkgs.jq}/bin/jq"
+        "/usr/bin/grep"
+        "/usr/bin/tr"
+      ]
       (builtins.readFile ./host-artifact-tailscale.sh)
   );
 

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -15,7 +15,11 @@
     "(allow file-read-data (literal \"@HOME@\"))",
     "(allow network-outbound (path \"@HOME@/ghq/github.com/nananaman/dotfiles/herdr/herdr.sock\"))",
     // Chrome bridgeは起動ごとに生成されるnative host socketで通信する。
-    "(allow network-outbound (subpath \"/private/tmp/codex-browser-use\"))"
+    "(allow network-outbound (subpath \"/private/tmp/codex-browser-use\"))",
+    // host-artifactは親sandboxから固定serviceとTailscale daemonだけを利用する。
+    "(allow network-outbound (remote tcp \"localhost:9417\"))",
+    "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))",
+    "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spki\"))"
   ],
   "groups": {
     "include": [
@@ -65,7 +69,10 @@
       // Google認証とcontainer registryで利用する。
       "accounts.google.com",
       "gcr.io",
-      "*.pkg.dev"
+      "*.pkg.dev",
+
+      // host-artifactが検証済みTailscale Serve URLを返すために利用する。
+      "*.ts.net"
     ]
   },
   "filesystem": {
@@ -110,153 +117,6 @@
   },
   "command_policies": {
     "commands": {
-      "host-artifact-service": {
-        "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact-service",
-        "from": {
-          "session": {
-            "sandbox": {
-              "fs_read_file": [
-                "/bin/launchctl",
-                "/bin/sleep",
-                "/usr/bin/curl",
-                "/usr/bin/seq"
-              ],
-              "unsafe_macos_seatbelt_rules": [
-                "(allow process-exec (literal \"/bin/launchctl\"))",
-                "(allow process-exec (literal \"/bin/sleep\"))",
-                "(allow process-exec (literal \"/usr/bin/curl\"))",
-                "(allow process-exec (literal \"/usr/bin/seq\"))",
-                "(allow network-outbound (remote tcp \"localhost:9417\"))"
-              ]
-            },
-            "invocation_policy": {
-              "default": "deny",
-              "allow": [{ "argv": { "exact": ["ensure"] } }]
-            }
-          },
-          "host-artifact": {
-            "sandbox": {
-              "fs_read_file": [
-                "/bin/launchctl",
-                "/bin/sleep",
-                "/usr/bin/curl",
-                "/usr/bin/seq"
-              ],
-              "unsafe_macos_seatbelt_rules": [
-                "(allow process-exec (literal \"/bin/launchctl\"))",
-                "(allow process-exec (literal \"/bin/sleep\"))",
-                "(allow process-exec (literal \"/usr/bin/curl\"))",
-                "(allow process-exec (literal \"/usr/bin/seq\"))",
-                "(allow network-outbound (remote tcp \"localhost:9417\"))"
-              ]
-            },
-            "invocation_policy": {
-              "default": "deny",
-              "allow": [{ "argv": { "exact": ["ensure"] } }]
-            }
-          }
-        }
-      },
-      "host-artifact": {
-        "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact",
-        "can_use": ["host-artifact-service", "host-artifact-tailscale", "host-artifact-workspace"],
-        "from": {
-          "session": {
-            "sandbox": {
-              "fs_read": [
-                "/nix/store",
-                "$HOME/.agents/skills/host-artifact",
-                "$WORKDIR",
-                "$TMPDIR"
-              ],
-              "fs_read_file": ["/usr/bin/shlock"],
-              "fs_write": ["$HOME/.local/share/host-artifact/public"],
-              "unsafe_macos_seatbelt_rules": [
-                "(allow process-exec (literal \"@BUN@\"))",
-                "(allow process-exec (literal \"/usr/bin/shlock\"))",
-                "(allow network-outbound (remote tcp \"localhost:9417\"))"
-              ]
-            },
-            "invocation_policy": {
-              "default": "deny",
-              "allow": [
-                { "argv": { "exact": ["status"] } },
-                { "argv": { "exact": ["setup"] } },
-                { "argv": { "prefix": ["publish"] } },
-                { "argv": { "prefix": ["remove"] } }
-              ]
-            }
-          }
-        }
-      },
-      "host-artifact-tailscale": {
-        "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact-tailscale",
-        "from": {
-          "host-artifact": {
-            "sandbox": {
-              "environment": { "allow_vars": ["HOME", "WORKDIR", "TMPDIR", "PATH", "LANG", "LC_*"] },
-              "fs_read": ["/nix/store", "/Applications/Tailscale.app"],
-              "fs_read_file": [
-                "$WORKDIR",
-                "/bin/sh",
-                "/bin/bash",
-                "/usr/local/bin/tailscale",
-                "/Applications/Tailscale.app/Contents/MacOS/tailscale",
-                "/usr/bin/curl",
-                "/usr/bin/grep",
-                "/usr/bin/tr"
-              ],
-              "unsafe_macos_seatbelt_rules": [
-                "(allow process-exec (subpath \"/nix/store\"))",
-                "(allow process-exec (literal \"/bin/sh\"))",
-                "(allow process-exec (literal \"/bin/bash\"))",
-                "(allow process-exec (literal \"/usr/local/bin/tailscale\"))",
-                "(allow process-exec (literal \"/Applications/Tailscale.app/Contents/MacOS/tailscale\"))",
-                "(allow process-exec (literal \"/usr/bin/curl\"))",
-                "(allow process-exec (literal \"/usr/bin/grep\"))",
-                "(allow process-exec (literal \"/usr/bin/tr\"))",
-                "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))",
-                "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spki\"))",
-                "(allow network-outbound (remote tcp \"localhost:*\"))",
-                "(allow network-outbound (remote tcp \"*:443\"))"
-              ]
-            },
-            "invocation_policy": {
-              "default": "deny",
-              "allow": [
-                { "argv": { "exact": ["inspect"] } },
-                { "argv": { "exact": ["setup"] } },
-                { "argv": { "prefix": ["verify"] } }
-              ]
-            }
-          }
-        }
-      },
-      "host-artifact-workspace": {
-        "executable": "@HOME@/.local/share/nono-agent-wrappers/host-artifact-workspace",
-        "from": {
-          "host-artifact": {
-            "sandbox": {
-              "environment": { "allow_vars": ["HOME", "WORKDIR", "TMPDIR", "PATH", "LANG", "LC_*"] },
-              "fs_read": ["$WORKDIR", "$HOME/ghq", "/nix/store"],
-              "fs_read_file": ["/usr/bin/git", "/usr/bin/shasum", "/usr/bin/perl", "/usr/bin/sed", "/usr/bin/tr", "/usr/bin/cut"],
-              "unsafe_macos_seatbelt_rules": [
-                "(allow process-exec (subpath \"/nix/store\"))",
-                "(allow process-exec (literal \"/usr/bin/git\"))",
-                "(allow process-exec (literal \"/usr/bin/shasum\"))",
-                "(allow process-exec (literal \"/usr/bin/perl\"))",
-                "(allow process-exec (literal \"/usr/bin/sed\"))",
-                "(allow process-exec (literal \"/usr/bin/tr\"))",
-                "(allow process-exec (literal \"/usr/bin/cut\"))"
-              ]
-            },
-            "invocation_policy": {
-              "default": "deny",
-              "allow": [{ "argv": { "exact": ["resolve"] } }]
-            }
-          }
-        }
-      },
       "container": {
         "executable": "/opt/homebrew/opt/container/libexec/container",
         "from": {

--- a/tests/fixtures/fake-curl.sh
+++ b/tests/fixtures/fake-curl.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-printf 'HTTP/2 %s\r\nX-Host-Artifact-Revision: %s\r\n\r\n' "${FAKE_CURL_STATUS:-200}" "$FAKE_CURL_REVISION"
+printf 'HTTP/2 %s\r\n%s: %s\r\n\r\n' \
+  "${FAKE_CURL_STATUS:-200}" "${FAKE_CURL_REVISION_HEADER:-X-Host-Artifact-Revision}" \
+  "${FAKE_CURL_RESPONSE_REVISION:-$FAKE_CURL_REVISION}"
 printf 'Host-Artifact-Status: %s\n' "${FAKE_CURL_STATUS:-200}"

--- a/tests/fixtures/fake-host-artifact-bun.sh
+++ b/tests/fixtures/fake-host-artifact-bun.sh
@@ -5,8 +5,8 @@ shift
 for helper in host-artifact-service host-artifact-tailscale host-artifact-workspace; do
   resolved="$(command -v "$helper")"
   case "$resolved" in
-    "$NONO_TOOL_SANDBOX_SHIM_DIR"/*) ;;
-    *) echo "helper bypassed shim: $helper -> $resolved" >&2; exit 1 ;;
+    "$HOST_ARTIFACT_EXPECTED_HELPER_DIR"/*) ;;
+    *) echo "helper did not use fixed package path: $helper -> $resolved" >&2; exit 1 ;;
   esac
 done
 printf '%s\n' "$*" >>"$HOST_ARTIFACT_FAKE_BUN_LOG"

--- a/tests/host-artifact-helpers.sh
+++ b/tests/host-artifact-helpers.sh
@@ -19,29 +19,33 @@ render_helpers() {
     nix/modules/home/host-artifact-workspace.sh >"$test_root/workspace-helper"
 }
 
-test_public_wrapper_prefers_command_policy_shims_for_every_operation() {
+test_public_wrapper_uses_fixed_helpers_without_command_policy_shims() {
   local operation
 
-  # Arrange: Trusted wrappers precede the broker shim directory in the inherited PATH.
+  # Arrange: A hostile inherited PATH and broker shim directory contain failing helpers.
   mkdir "$test_root/wrappers" "$test_root/shims"
   cp "$repository_root/tests/fixtures/fake-host-artifact-bun.sh" "$test_root/fake-bun"
   chmod +x "$test_root/fake-bun"
+  mkdir "$test_root/helpers"
   for helper in host-artifact-service host-artifact-tailscale host-artifact-workspace; do
     printf '#!/bin/sh\nexit 1\n' >"$test_root/wrappers/$helper"
     printf '#!/bin/sh\nexit 0\n' >"$test_root/shims/$helper"
-    chmod +x "$test_root/wrappers/$helper" "$test_root/shims/$helper"
+    printf '#!/bin/sh\nexit 0\n' >"$test_root/helpers/$helper"
+    chmod +x "$test_root/wrappers/$helper" "$test_root/shims/$helper" "$test_root/helpers/$helper"
   done
   sed -e "s|@BUN@|$test_root/fake-bun|g" -e "s|@CLI@|$test_root/cli.ts|g" \
+    -e "s|@HELPER_PATH@|$test_root/helpers|g" \
     nix/modules/home/host-artifact.sh >"$test_root/host-artifact"
   : >"$test_root/bun.log"
 
   # Act: Exercise every accepted public operation through the generated wrapper.
   for operation in 'publish report.html --name report' 'remove --name report' 'status' 'setup'; do
     PATH="$test_root/wrappers:/usr/bin:/bin" NONO_TOOL_SANDBOX_SHIM_DIR="$test_root/shims" \
+      HOST_ARTIFACT_EXPECTED_HELPER_DIR="$test_root/helpers" \
       HOST_ARTIFACT_FAKE_BUN_LOG="$test_root/bun.log" bash "$test_root/host-artifact" $operation
   done
 
-  # Assert: Bun observed all operations only after every helper resolved to a policy shim.
+  # Assert: Bun observed all operations with helpers pinned ahead of inherited paths and shims.
   [ "$(wc -l <"$test_root/bun.log" | tr -d ' ')" -eq 4 ]
 }
 
@@ -220,6 +224,36 @@ test_verify_constructs_the_only_remote_url_and_checks_revision() {
   jq -e '.verified and .url == "https://machine.tailnet.ts.net/a/owner-repo~012345abcdef/report/"' <<<"$output" >/dev/null
 }
 
+test_verify_accepts_lowercase_http2_revision_header() {
+  # Arrange: HTTP/2 normalizes the application response header name to lowercase.
+  write_online_status
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9417"}}}}}' >"$test_root/serve.json"
+  revision="r-0123456789abcdef0123456789abcdef"
+
+  # Act: Verify the artifact against a lowercase revision header.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_CURL_REVISION="$revision" FAKE_CURL_REVISION_HEADER="x-host-artifact-revision" \
+    bash "$test_root/tailscale-helper" verify owner-repo~012345abcdef report "$revision")"
+
+  # Assert: Header field names are matched case-insensitively as required by HTTP.
+  jq -e '.verified == true' <<<"$output" >/dev/null
+}
+
+test_verify_rejects_a_case_mismatched_revision_value() {
+  # Arrange: The header name is valid but the opaque revision value changes case.
+  write_online_status
+  printf '%s\n' '{"Web":{"machine.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9417"}}}}}' >"$test_root/serve.json"
+  revision="r-0123456789abcdef0123456789abcdef"
+
+  # Act: Verify against a response whose revision is not byte-for-byte equal.
+  output="$(FAKE_TAILSCALE_STATUS="$test_root/status.json" FAKE_TAILSCALE_SERVE="$test_root/serve.json" \
+    FAKE_CURL_REVISION="$revision" FAKE_CURL_RESPONSE_REVISION="R-0123456789ABCDEF0123456789ABCDEF" \
+    bash "$test_root/tailscale-helper" verify owner-repo~012345abcdef report "$revision")"
+
+  # Assert: Only the field name is case-insensitive; the opaque value remains exact.
+  jq -e '. == {schemaVersion:1,verified:false,reason:"remote-verification-failed"}' <<<"$output" >/dev/null
+}
+
 test_verify_rejects_a_non_success_response_with_matching_revision() {
   # Arrange: A redirect happens to echo the expected revision header.
   write_online_status
@@ -296,7 +330,7 @@ test_workspace_resolve_keeps_linked_worktree_identity() {
 }
 
 render_helpers
-test_public_wrapper_prefers_command_policy_shims_for_every_operation
+test_public_wrapper_uses_fixed_helpers_without_command_policy_shims
 test_inspect_reports_configured_serve_without_exposing_external_state
 test_inspect_rejects_conflicting_root_target
 test_inspect_fails_closed_when_serve_status_fails
@@ -310,6 +344,8 @@ test_inspect_falls_back_to_the_app_executable
 test_inspect_degrades_when_tailscale_is_offline
 test_setup_configures_only_an_empty_serve_root
 test_verify_constructs_the_only_remote_url_and_checks_revision
+test_verify_accepts_lowercase_http2_revision_header
+test_verify_rejects_a_case_mismatched_revision_value
 test_verify_rejects_a_non_success_response_with_matching_revision
 test_workspace_resolve_normalizes_a_remote_repository
 test_workspace_resolve_ignores_hostile_global_git_config

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -99,14 +99,14 @@ test_ensure_wrapper_requires_the_server_identity() {
   rg -q '\{"service":"host-artifact","version":2,"status":"ok",'\''\*' "$packages_module"
 }
 
-test_profile_grants_only_the_publish_root_and_exact_ensure_command() {
+test_profile_grants_only_the_publish_root_without_host_artifact_tool_policies() {
   local profile_json
 
   # Arrange: Strip JSONC comments so policy values can be queried structurally.
   profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
 
   # Act: Select the filesystem and command capabilities added for artifact hosting.
-  # Assert: The writable path and executable are exact, and every other argv is denied.
+  # Assert: The writable path is exact and host-artifact inherits the parent sandbox.
   jq -e '
     .filesystem.allow
     | index("$HOME/.local/share/host-artifact/public") != null
@@ -120,35 +120,9 @@ test_profile_grants_only_the_publish_root_and_exact_ensure_command() {
     | index("$HOME/.local/share/host-artifact") == null
   ' <<<"$profile_json" >/dev/null
   jq -e '
-    .command_policies.commands["host-artifact-service"]
-      .executable == "@HOME@/.local/share/nono-agent-wrappers/host-artifact-service"
-  ' <<<"$profile_json" >/dev/null
-  jq -e '
-    .command_policies.commands["host-artifact-service"].from.session.invocation_policy
-      == {"default":"deny","allow":[{"argv":{"exact":["ensure"]}}]}
-  ' <<<"$profile_json" >/dev/null
-}
-
-test_ensure_command_sandbox_executes_only_its_fixed_dependencies() {
-  local profile_json
-
-  # Arrange: Normalize the source profile without resolving it against host state.
-  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
-
-  # Act: Select files executable by the fixed ensure implementation.
-  # Assert: The child sandbox exposes only launchctl and its bounded health helpers.
-  jq -e '
-    .command_policies.commands["host-artifact-service"].from.session.sandbox.fs_read_file
-      == ["/bin/launchctl", "/bin/sleep", "/usr/bin/curl", "/usr/bin/seq"]
-  ' <<<"$profile_json" >/dev/null
-  jq -e '
-    .command_policies.commands["host-artifact-service"].from.session.sandbox
-      | has("network") | not
-  ' <<<"$profile_json" >/dev/null
-  jq -e '
-    .command_policies.commands["host-artifact-service"].from.session.sandbox
-      .unsafe_macos_seatbelt_rules
-      | index("(allow network-outbound (remote tcp \"localhost:9417\"))") != null
+    . as $profile
+    | ["host-artifact","host-artifact-service","host-artifact-tailscale","host-artifact-workspace"]
+    | all(. as $command | $profile.command_policies.commands | has($command) | not)
   ' <<<"$profile_json" >/dev/null
 }
 
@@ -232,132 +206,31 @@ test_activation_installs_frozen_bun_dependencies_before_service_use() {
   rg -q 'bun\.lock' "$module" || return 1
 }
 
-test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper() {
+test_agent_cli_runs_typescript_with_fixed_helpers_in_the_parent_sandbox() {
   local profile_json
 
   # Arrange: Direct bun invocation is unavailable in the parent agent sandbox.
   profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
 
   # Act: Inspect the wrapper and its command-policy boundary.
-  # Assert: The trusted wrapper runs only the installed CLI source with bounded public argv.
+  # Assert: The wrapper pins Bun, the CLI, and helper packages without broker shims.
   rg -q 'writeShellScriptBin "host-artifact"' "$packages_module" || return 1
   rg -q 'src/cli\.ts' "$packages_module" || return 1
   if rg -q -- '--no-reload|--tailscale|host PATH|update ARTIFACT' "$packages_module"; then return 1; fi
-  jq -e '
-    .command_policies.commands["host-artifact"].can_use
-      == ["host-artifact-service","host-artifact-tailscale","host-artifact-workspace"]
-  ' <<<"$profile_json" >/dev/null
-  jq -e '
-    .command_policies.commands["host-artifact"].from.session.sandbox
-      | has("network") | not
-  ' <<<"$profile_json" >/dev/null
-  jq -e '
-    .command_policies.commands["host-artifact"].from.session.sandbox.fs_read
-      | index("/nix/store") != null
-  ' <<<"$profile_json" >/dev/null || return 1
-  jq -e '
-    .command_policies.commands["host-artifact"].from.session.sandbox
-      .unsafe_macos_seatbelt_rules
-      | index("(allow network-outbound (remote tcp \"localhost:9417\"))") != null
-  ' <<<"$profile_json" >/dev/null
-  jq -e '
-    .command_policies.commands["host-artifact"].from.session.invocation_policy
-      == {
-        "default":"deny",
-        "allow":[
-          {"argv":{"exact":["status"]}},
-          {"argv":{"exact":["setup"]}},
-          {"argv":{"prefix":["publish"]}},
-          {"argv":{"prefix":["remove"]}}
-        ]
-      }
-  ' <<<"$profile_json" >/dev/null
-  jq -e '
-    .command_policies.commands["host-artifact-service"]
-      .from["host-artifact"].invocation_policy
-      == {"default":"deny","allow":[{"argv":{"exact":["ensure"]}}]}
-  ' <<<"$profile_json" >/dev/null
+  rg -q '"@HELPER_PATH@"' "$packages_module" || return 1
+  rg -q 'lib\.makeBinPath' "$packages_module" || return 1
+  rg -q 'PATH="@HELPER_PATH@:\$PATH"' nix/modules/home/host-artifact.sh || return 1
+  if rg -q 'NONO_TOOL_SANDBOX_SHIM_DIR' nix/modules/home/host-artifact.sh; then return 1; fi
+  jq -e '.command_policies.commands | has("host-artifact") | not' <<<"$profile_json" >/dev/null
 }
 
-test_agent_cli_grants_only_the_fixed_shlock_executable() {
+test_agent_cli_does_not_add_a_shlock_tool_sandbox() {
   local profile_json
   profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
 
-  # Arrange: The publisher acquires PID locks with direct execFile of the system shlock binary.
-  # Act: Inspect executable and filesystem capabilities of the main CLI child sandbox.
-  # Assert: Only the exact binary is added; lock/temp mutations remain under the existing publish root.
-  jq -e '
-    .command_policies.commands["host-artifact"].from.session.sandbox as $sandbox
-    | ($sandbox.fs_read_file | index("/usr/bin/shlock")) != null
-    and ($sandbox.unsafe_macos_seatbelt_rules | index("(allow process-exec (literal \"/usr/bin/shlock\"))")) != null
-    and $sandbox.fs_write == ["$HOME/.local/share/host-artifact/public"]
-    and ($sandbox.fs_read_file | index("/usr/bin") == null)
-  ' <<<"$profile_json" >/dev/null
-}
-
-test_tailscale_helper_exposes_only_bounded_operations() {
-  local profile_json
-  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
-
-  # Arrange: The helper owns all Tailscale and remote-network access.
-  # Act & Assert: Its caller policy accepts only inspect/setup and grammar-shaped verify.
-  rg -q 'writeShellScriptBin "host-artifact-tailscale"' "$packages_module" || return 1
-  rg -Fq '"/usr/local/bin/tailscale" "/Applications/Tailscale.app/Contents/MacOS/tailscale"' "$packages_module" || return 1
-  jq -e '
-    .command_policies.commands["host-artifact-tailscale"].from["host-artifact"].invocation_policy
-      == {"default":"deny","allow":[
-        {"argv":{"exact":["inspect"]}},
-        {"argv":{"exact":["setup"]}},
-        {"argv":{"prefix":["verify"]}}
-      ]}
-  ' <<<"$profile_json" >/dev/null
-  jq -e '
-    .command_policies.commands["host-artifact-tailscale"].from["host-artifact"].sandbox as $sandbox
-    | $sandbox.unsafe_macos_seatbelt_rules as $rules
-    | $sandbox.fs_read == ["/nix/store","/Applications/Tailscale.app"]
-    and ($sandbox.fs_read_file | index("$WORKDIR") != null)
-    and ($sandbox.fs_read_file | index("/bin/bash") != null)
-    and ($rules | index("(allow process-exec (literal \"/bin/bash\"))") != null)
-    and ($rules | index("(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))")) != null
-    and ($rules | index("(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spki\"))")) != null
-    and ($rules | index("(allow mach-lookup)")) == null
-  ' <<<"$profile_json" >/dev/null
-}
-
-test_workspace_helper_exposes_only_resolve_with_bounded_repository_read() {
-  local profile_json
-  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
-
-  # Arrange: Workspace identity may need linked-worktree common metadata under ghq.
-  # Act & Assert: Only resolve is callable, repository roots are readable, and shasum's fixed interpreter is executable.
-  rg -q 'writeShellScriptBin "host-artifact-workspace"' "$packages_module" || return 1
-  jq -e '
-    .command_policies.commands["host-artifact-workspace"].from["host-artifact"].invocation_policy
-      == {"default":"deny","allow":[{"argv":{"exact":["resolve"]}}]}
-    and (.command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.fs_read
-      == ["$WORKDIR","$HOME/ghq","/nix/store"])
-    and (.command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.fs_read_file
-      | index("/usr/bin/perl") != null)
-    and (.command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.unsafe_macos_seatbelt_rules
-      | index("(allow process-exec (literal \"/usr/bin/perl\"))") != null)
-  ' <<<"$profile_json" >/dev/null
-}
-
-test_helper_command_sandboxes_strip_shell_startup_environment() {
-  local profile_json
-  profile_json="$(sed '/^[[:space:]]*[/][/]/d' "$profile")"
-
-  # Arrange: Both trusted helpers start as Bash scripts before they validate public argv.
-  # Act: Inspect the environment inherited by each helper command sandbox.
-  # Assert: Attacker-controlled startup hook variables are removed before Bash starts.
-  jq -e '
-    ["HOME","WORKDIR","TMPDIR","PATH","LANG","LC_*"] as $safe
-    | .command_policies.commands["host-artifact-tailscale"].from["host-artifact"].sandbox.environment.allow_vars
-      == $safe
-    and .command_policies.commands["host-artifact-workspace"].from["host-artifact"].sandbox.environment.allow_vars
-      == $safe
-    and ($safe | index("BASH_ENV") == null and index("ENV") == null and index("*") == null)
-  ' <<<"$profile_json" >/dev/null
+  # Arrange: The publisher acquires PID locks inside the existing parent sandbox.
+  # Act & Assert: No host-artifact-specific executable grant remains in the profile.
+  jq -e '.command_policies.commands | has("host-artifact") | not' <<<"$profile_json" >/dev/null
 }
 
 test_server_profile_reads_published_content_but_not_its_neighbor() {
@@ -426,19 +299,15 @@ test_activation_restarts_the_service_after_preparing_the_runtime || exit 1
 test_ensure_wrapper_exposes_only_the_ensure_operation
 test_ensure_wrapper_uses_a_finite_health_check
 test_ensure_wrapper_requires_the_server_identity
-test_profile_grants_only_the_publish_root_and_exact_ensure_command
-test_ensure_command_sandbox_executes_only_its_fixed_dependencies
+test_profile_grants_only_the_publish_root_without_host_artifact_tool_policies
 test_server_profile_is_read_only_and_listens_only_on_the_service_port
 test_launch_agent_runs_typescript_with_bun_through_nono || exit 1
 test_server_wrapper_has_no_tailscale_listener_state || exit 1
 test_server_wrapper_recycles_stale_runtime_after_skill_update || exit 1
 test_server_profile_has_no_tailscale_state_grant || exit 1
 test_activation_installs_frozen_bun_dependencies_before_service_use || exit 1
-test_agent_cli_runs_typescript_through_a_fixed_bun_wrapper || exit 1
-test_agent_cli_grants_only_the_fixed_shlock_executable || exit 1
-test_tailscale_helper_exposes_only_bounded_operations || exit 1
-test_workspace_helper_exposes_only_resolve_with_bounded_repository_read || exit 1
-test_helper_command_sandboxes_strip_shell_startup_environment || exit 1
+test_agent_cli_runs_typescript_with_fixed_helpers_in_the_parent_sandbox || exit 1
+test_agent_cli_does_not_add_a_shlock_tool_sandbox || exit 1
 test_server_profile_reads_published_content_but_not_its_neighbor
 test_server_profile_cannot_write_published_content
 test_server_profile_cannot_replace_the_publish_root

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -263,6 +263,12 @@ test_common_profile_allows_development_endpoints() {
   done
 }
 
+test_common_profile_allows_tailscale_serve_origins() {
+  # Arrange & Act: Evaluate a representative MagicDNS HTTPS origin without connecting to it.
+  # Assert: Host-artifact can verify its Tailscale Serve URL through the parent sandbox.
+  assert_host_decision "ALLOWED" "machine.tailnet.ts.net"
+}
+
 test_common_profile_denies_unconfigured_clouds() {
   assert_host_decision "DENIED" management.azure.com
 }
@@ -359,29 +365,19 @@ test_host_artifact_publish_root_is_writable_without_broadening_its_parent() {
     "write"
 }
 
-test_host_artifact_service_policy_allows_only_exact_ensure() {
-  # Arrange: Service recovery is delegated through one canonical wrapper.
-  # Act & Assert: The policy defaults to deny and grants only the argument-free ensure operation.
-  assert_profile_value \
-    '.command_policies.commands["host-artifact-service"].executable' \
-    '@HOME@/.local/share/nono-agent-wrappers/host-artifact-service'
-  assert_profile_value \
-    '.command_policies.commands["host-artifact-service"].from.session.invocation_policy.default' \
-    'deny'
-  assert_profile_value \
-    '.command_policies.commands["host-artifact-service"].from.session.invocation_policy.allow | tojson' \
-    '[{"argv":{"exact":["ensure"]}}]'
-}
+test_host_artifact_uses_the_parent_sandbox_without_tool_policies() {
+  local command
 
-test_host_artifact_service_policy_does_not_delegate_launchctl() {
-  # Arrange: Agents receive a fixed recovery operation rather than general service control.
-  # Act & Assert: launchctl itself has no command policy and no other wrapper argv is allowed.
+  # Arrange: Host-artifact wrappers validate their own bounded public arguments.
+  for command in host-artifact host-artifact-service host-artifact-tailscale host-artifact-workspace; do
+    # Act & Assert: None of the wrappers creates a nested Tool Sandbox boundary.
+    assert_profile_value ".command_policies.commands | has(\"$command\")" 'false'
+  done
+
+  # Act & Assert: Parent capability remains limited to the fixed service and Tailscale daemon names.
   assert_profile_value \
-    '.command_policies.commands | has("launchctl")' \
-    'false'
-  assert_profile_value \
-    '.command_policies.commands["host-artifact-service"].from.session.invocation_policy.allow | length' \
-    '1'
+    '[.unsafe_macos_seatbelt_rules[] | select(test("host-artifact|tailscale|localhost:9417"; "i"))] | tojson' \
+    '["(allow network-outbound (remote tcp \"localhost:9417\"))","(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))","(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spki\"))"]'
 }
 
 test_bun_uses_the_outer_sandbox_with_exact_ancestor_rules() {
@@ -432,6 +428,7 @@ test_common_profile_keeps_chrome_data_outside_direct_agent_access
 test_common_profile_allows_only_the_chrome_bridge_socket_subtree
 test_common_profile_uses_enterprise_network
 test_common_profile_allows_development_endpoints
+test_common_profile_allows_tailscale_serve_origins
 test_common_profile_denies_unconfigured_clouds
 test_common_profile_allows_all_ghq_repositories
 test_common_profile_allows_new_ghq_clone_destinations
@@ -442,8 +439,7 @@ test_container_policy_keeps_destructive_cleanup_denied
 test_codex_wrapper_requires_the_parent_nono_capability
 test_local_agent_tools_use_the_parent_sandbox
 test_host_artifact_publish_root_is_writable_without_broadening_its_parent
-test_host_artifact_service_policy_allows_only_exact_ensure
-test_host_artifact_service_policy_does_not_delegate_launchctl
+test_host_artifact_uses_the_parent_sandbox_without_tool_policies
 test_bun_uses_the_outer_sandbox_with_exact_ancestor_rules
 test_codex_allows_chatgpt_subscription_endpoint
 test_codex_allows_unrestricted_localhost_outbound_on_macos


### PR DESCRIPTION
## Summary
- host-artifact の多段 Tool Sandbox chain を廃止し、親 sandbox と固定 Nix helper path で実行する
- Tailscale Serve の setup/status/publish を実機で復旧し、検証済み HTTPS URL を返せるようにする

## Changes
- host-artifact 関連の command policy 4件を削除し、wrapperからNix store上のhelperを固定解決する
- publish rootとread-only server sandboxを維持しつつ、localhost service、Tailscale daemon、MagicDNS HTTPSに必要な親profile capabilityだけを追加する
- HTTP/2で小文字化されるrevision header名をcase-insensitiveに扱い、revision値はexact一致のまま検証する
- shim非依存、profile境界、lowercase header、case不一致revisionの回帰テストを追加する

## Tests
- `bash tests/host-artifact-helpers.sh`
- `bash tests/host-artifact-service.sh`
- `nono profile validate --strict nono/profiles/chouge-agent-common.jsonc`
- `nix-instantiate --parse nix/modules/home/packages.nix`
- `nixfmt --check nix/modules/home/packages.nix`
- `git diff --check`
- Home Manager switch後に `host-artifact status` と `host-artifact publish` を実行し、`transport: tailscale-serve` のHTTPS URLを実機検証
- `nix run .#build` はagent sandboxからNix daemon socketへ接続できず未完了。ユーザーによる `nix run .#switch` は成功

## Review notes
- Review gate: `review-diff-code`、base `origin/main`、専門reviewer 2名 + blind adversarial reviewer、全reviewer成功
- 採用finding: HTTP header名のcase-insensitive比較がrevision値にも及ぶ問題を修正し、値のcase不一致テストを追加
- 親sessionのTailscale daemon capabilityと `*.ts.net` 許可は、command policyを廃止して親sandboxへ統合する明示的な設計判断としてreject。credential、workspace、publish rootの権限は拡大していない
- plan markerなし
