### PR TITLE
fix(darwin): macOSユーザーごとの構成を選択する

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,9 +41,10 @@
       ...
     }:
     let
-      darwinUsername = "juntawatanabe";
-      darwinHomedir = "/Users/${darwinUsername}";
-      darwinDotfilesDir = "${darwinHomedir}/ghq/github.com/nananaman/dotfiles";
+      darwinUsernames = [
+        "juntawatanabe"
+        "chouge"
+      ];
 
       wslUsername = "chouge";
       wslHomedir = "/home/${wslUsername}";
@@ -70,12 +71,6 @@
         let
           pkgs = mkPkgs system;
           isDarwin = system == "aarch64-darwin";
-          configName = if isDarwin then darwinUsername else wslUsername;
-          buildTarget =
-            if isDarwin then
-              "darwinConfigurations.${configName}.system"
-            else
-              "homeConfigurations.${configName}.activationPackage";
           homeManager = home-manager.packages.${system}.home-manager;
         in
         {
@@ -85,12 +80,23 @@
             build = {
               type = "app";
               program = toString (
-                pkgs.writeShellScript "nix-build-config" ''
-                  set -e
-                  echo "Building ${buildTarget}..."
-                  nix build .#${buildTarget}
-                  echo "Build successful! Run 'nix run .#switch' to apply."
-                ''
+                pkgs.writeShellScript "nix-build-config" (
+                  if isDarwin then
+                    ''
+                      set -e
+                      config_name="$(${pkgs.bash}/bin/bash ${./nix/scripts/select-darwin-configuration.sh} "$(id -un)" ${pkgs.lib.escapeShellArgs darwinUsernames})"
+                      echo "Building darwinConfigurations.$config_name.system..."
+                      nix build ".#darwinConfigurations.$config_name.system"
+                      echo "Build successful! Run 'nix run .#switch' to apply."
+                    ''
+                  else
+                    ''
+                      set -e
+                      echo "Building homeConfigurations.${wslUsername}.activationPackage..."
+                      nix build .#homeConfigurations.${wslUsername}.activationPackage
+                      echo "Build successful! Run 'nix run .#switch' to apply."
+                    ''
+                )
               );
             };
 
@@ -101,15 +107,16 @@
                   if isDarwin then
                     ''
                       set -eo pipefail
+                      config_name="$(${pkgs.bash}/bin/bash ${./nix/scripts/select-darwin-configuration.sh} "$(id -un)" ${pkgs.lib.escapeShellArgs darwinUsernames})"
                       echo "Building and switching to darwin configuration..."
-                      sudo nix run nix-darwin -- switch --flake .#${configName}
+                      sudo -H nix run nix-darwin -- switch --flake ".#$config_name"
                       echo "Done!"
                     ''
                   else
                     ''
                       set -eo pipefail
                       echo "Building and switching to home-manager configuration..."
-                      ${homeManager}/bin/home-manager switch --flake .#${configName}
+                      ${homeManager}/bin/home-manager switch --flake .#${wslUsername}
                       echo "Done!"
                     ''
                 )
@@ -134,56 +141,61 @@
         let
           darwinSystem = "aarch64-darwin";
           darwinPkgs = mkPkgs darwinSystem;
+          mkDarwinConfiguration =
+            username:
+            let
+              homedir = "/Users/${username}";
+              dotfilesDir = "${homedir}/ghq/github.com/nananaman/dotfiles";
+            in
+            nix-darwin.lib.darwinSystem {
+              system = darwinSystem;
+
+              modules = [
+                (import ./nix/modules/darwin/system.nix {
+                  pkgs = darwinPkgs;
+                  inherit (darwinPkgs) lib;
+                  inherit username homedir;
+                })
+
+                home-manager.darwinModules.home-manager
+                {
+                  home-manager = {
+                    useGlobalPkgs = true;
+                    useUserPackages = true;
+                    backupFileExtension = "hm-backup";
+                    users.${username} =
+                      {
+                        pkgs,
+                        config,
+                        lib,
+                        ...
+                      }:
+                      let
+                        helpers = import ./nix/modules/lib/helpers { inherit lib; };
+                      in
+                      {
+                        imports = [
+                          (import ./nix/modules/home {
+                            inherit
+                              pkgs
+                              config
+                              lib
+                              helpers
+                              dotfilesDir
+                              ;
+                            herdrPackage = herdr.packages.${pkgs.system}.default;
+                            hunkInput = hunk;
+                            codexCliPackage = codex-cli-nix.packages.${pkgs.system}.codex;
+                          })
+                        ];
+                      };
+                  };
+                }
+              ];
+            };
         in
         {
-          darwinConfigurations.${darwinUsername} = nix-darwin.lib.darwinSystem {
-            system = darwinSystem;
-
-            modules = [
-              (import ./nix/modules/darwin/system.nix {
-                pkgs = darwinPkgs;
-                inherit (darwinPkgs) lib;
-                username = darwinUsername;
-                homedir = darwinHomedir;
-              })
-
-              home-manager.darwinModules.home-manager
-              {
-                home-manager = {
-                  useGlobalPkgs = true;
-                  useUserPackages = true;
-                  backupFileExtension = "hm-backup";
-                  users.${darwinUsername} =
-                    {
-                      pkgs,
-                      config,
-                      lib,
-                      ...
-                    }:
-                    let
-                      helpers = import ./nix/modules/lib/helpers { inherit lib; };
-                      dotfilesDir = darwinDotfilesDir;
-                    in
-                    {
-                      imports = [
-                        (import ./nix/modules/home {
-                          inherit
-                            pkgs
-                            config
-                            lib
-                            helpers
-                            dotfilesDir
-                            ;
-                          herdrPackage = herdr.packages.${pkgs.system}.default;
-                          hunkInput = hunk;
-                          codexCliPackage = codex-cli-nix.packages.${pkgs.system}.codex;
-                        })
-                      ];
-                    };
-                };
-              }
-            ];
-          };
+          darwinConfigurations = darwinPkgs.lib.genAttrs darwinUsernames mkDarwinConfiguration;
 
           homeConfigurations.${wslUsername} = home-manager.lib.homeManagerConfiguration {
             pkgs = mkPkgs "x86_64-linux";

--- a/nix/scripts/select-darwin-configuration.sh
+++ b/nix/scripts/select-darwin-configuration.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+username="${1:-$(id -un)}"
+shift || true
+
+for configuration_name in "$@"; do
+  if [[ "$username" == "$configuration_name" ]]; then
+    printf '%s\n' "$username"
+    exit 0
+  fi
+done
+
+printf 'Unsupported macOS user: %s\n' "$username" >&2
+exit 1

--- a/tests/darwin-configurations.sh
+++ b/tests/darwin-configurations.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+selector="nix/scripts/select-darwin-configuration.sh"
+darwin_configurations=(juntawatanabe chouge)
+
+test_each_supported_macos_user_selects_its_matching_configuration() {
+  local username
+  local actual
+
+  for username in juntawatanabe chouge; do
+    # Arrange: 対応対象のmacOSユーザー名を明示して、実PCの状態から隔離する。
+    # Act: switchとbuildが共有するconfiguration選択処理を実行する。
+    actual="$(bash "$selector" "$username" "${darwin_configurations[@]}")"
+
+    # Assert: PCごとのユーザー名と同名のFlake configurationが選択される。
+    [[ "$actual" == "$username" ]]
+  done
+}
+
+test_unknown_macos_user_is_rejected() {
+  # Arrange: Flakeに定義されていないmacOSユーザー名を指定する。
+  # Act & Assert: 誤ったユーザー向け構成へfallbackせず失敗する。
+  if bash "$selector" unknown-user "${darwin_configurations[@]}" >/dev/null 2>&1; then
+    return 1
+  fi
+}
+
+test_distributed_zsh_config_does_not_depend_on_a_literal_home_directory() {
+  # Arrange: Home Managerが両方のmacOSユーザーへ配布するzsh設定を対象にする。
+  # Act & Assert: macOSまたはLinux固有のliteralなhome directoryが残っていないことを確認する。
+  if grep -En '/(Users|home)/[^/[:space:]]+/' zsh/zshrc; then
+    return 1
+  fi
+}
+
+test_each_supported_macos_user_selects_its_matching_configuration
+test_unknown_macos_user_is_rejected
+test_distributed_zsh_config_does_not_depend_on_a_literal_home_directory

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -67,13 +67,13 @@ fi
 # Vite+ bin (https://viteplus.dev)
 [ -f "$HOME/.vite-plus/env" ] && . "$HOME/.vite-plus/env"
 
-export PATH=/Users/juntawatanabe/.ticloud/bin:$PATH
+export PATH="$HOME/.ticloud/bin:$PATH"
 
 # Added by cua-driver installer — see https://github.com/trycua/cua
 export PATH="$HOME/.local/bin:$PATH"
 
 # pnpm
-export PNPM_HOME="/home/chouge/.local/share/pnpm"
+export PNPM_HOME="$HOME/.local/share/pnpm"
 case ":$PATH:" in
   *":$PNPM_HOME/bin:"*) ;;
   *) export PATH="$PNPM_HOME/bin:$PATH" ;;
@@ -81,7 +81,7 @@ esac
 # pnpm end
 
 # bun completions
-[ -s "/home/chouge/.bun/_bun" ] && source "/home/chouge/.bun/_bun"
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
 # bun
 export BUN_INSTALL="$HOME/.bun"


### PR DESCRIPTION
## Summary
- PCごとに異なるmacOSユーザー名で同じdotfilesを適用できるようにする
- `sudo` 実行時にユーザーのHOMEが引き継がれる警告を解消する

## Changes
- `juntawatanabe` と `chouge` の `darwinConfigurations` を共通factoryから生成
- `nix run .#build` / `nix run .#switch` で現在のユーザーに一致する構成を選択
- 未対応ユーザーを明示的に拒否するselectorとテストを追加
- 共有zsh設定のliteralなhome directoryを `$HOME` ベースへ変更

## Tests
- `nix-instantiate --parse flake.nix`
- `bash tests/darwin-configurations.sh`
- `bash -n nix/scripts/select-darwin-configuration.sh tests/darwin-configurations.sh`
- `zsh -n zsh/zshrc`
- `git diff --check`
- `nix run .#build` は実行環境からNix daemon socketへの接続が拒否されたため未実行

## Review notes
- Review gate: `review-diff-code`、base `origin/main`
- Nix Darwin Portability reviewer: actionable findingなし
- Blind Adversarial reviewer: actionable findingなし
- Reviewer isolation: context-level isolation
