### PR TITLE
fix(darwin): 1Password CLIをHomebrew管理する

### DIFF
--- a/nix/modules/darwin/system.nix
+++ b/nix/modules/darwin/system.nix
@@ -74,6 +74,7 @@
     ];
 
     casks = [
+      "1password-cli"
       "ghostty"
       "nikitabobko/tap/aerospace"
     ];


### PR DESCRIPTION
## Summary
- Homebrew cleanup後も1Password CLIを利用できるようにする

## Changes
- `1password-cli`をnix-darwin管理のCaskへ追加
- Google Cloud CLIは既存のNix管理版`google-cloud-sdk`を継続利用

## Tests
- `nixfmt nix/modules/darwin/system.nix`
- `nix-instantiate --parse flake.nix`
- `git diff --check`
- `nix run .#build`は実行環境からNix daemon socketへの接続が拒否されるため未実行

## Review notes
- Review gate: `review-diff-code`、base `origin/main`
- Homebrew Declaration reviewer: actionable findingなし
- Blind Adversarial reviewer: actionable findingなし
- Reviewer isolation: context-level isolation
