### PR TITLE
fix(nono): FlutterとDartの開発コマンドを許可する

### DIFF
--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -63,7 +63,8 @@ in
     link_force "${dotfilesDir}/srt" "${configHome}/srt"
 
     $DRY_RUN_CMD mkdir -p "${configHome}/nono/profiles"
-    $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/wrangler"
+    $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/wrangler" "${homeDirectory}/.local/state/nono-agent-tools/pub-cache"
+    $DRY_RUN_CMD mkdir -p "${homeDirectory}/.dart-tool" "${homeDirectory}/.dartServer" "${configHome}/flutter"
     for legacy_profile in chouge-agent-common chouge-codex chouge-claude chouge-pi; do
       legacy_path="${configHome}/nono/profiles/$legacy_profile.json"
       legacy_target="$(readlink "$legacy_path" 2>/dev/null || true)"

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -8,6 +8,8 @@
   },
   "environment": {
     "set_vars": {
+      // credentialを含み得る既存cacheへwriteを広げず、agent専用のDart package cacheを使う。
+      "PUB_CACHE": "$HOME/.local/state/nono-agent-tools/pub-cache",
       // pnpmのlifecycle runnerがproject-local executableを直接spawnするとmacOS Seatbeltに拒否されるため、
       // 既に許可されたsystem shellを明示して同じsandbox境界内で実行する。
       "npm_config_script_shell": "/bin/sh",
@@ -79,6 +81,8 @@
       "*.anthropic.com",
       "proxy.golang.org",
       "sum.golang.org",
+      // Dart/Flutter dependency resolution。
+      "pub.dev",
       // OpenAIの開発者向け文書とGitHub Releasesの成果物取得で利用する。
       "developers.openai.com",
       "release-assets.githubusercontent.com",
@@ -107,6 +111,10 @@
       "$HOME/.local/share/nvim",
       "$HOME/.local/state/nvim",
       "$HOME/.local/state/mise",
+      // Dart CLIとFlutter toolが保持するtelemetry/tool state。credentialは含まない。
+      "$HOME/.dart-tool",
+      "$HOME/.dartServer",
+      "$HOME/.config/flutter",
       "$HOME/.local/share/host-artifact/public",
       "$HOME/go/pkg/mod",
       // ghq管理のrepositoryを調査、clone、修正できるようにする。
@@ -115,8 +123,19 @@
       // 書き込みを行うため、read-onlyでは機能しない。loginなどの新規発行はsandbox外で行う運用は維持する。
       "$HOME/.config/gcloud",
       "$HOME/.local/state/nono-agent-tools/wrangler",
+      "$HOME/.local/state/nono-agent-tools/pub-cache",
     ],
-    "allow_file": ["$HOME/.claude.json", "$HOME/.claude.json.lock", "$HOME/.claude.lock"],
+    "allow_file": [
+      "$HOME/.claude.json",
+      "$HOME/.claude.json.lock",
+      "$HOME/.claude.lock",
+      // katohome-monorepo/mobileがpinするFlutter SDKで観測済みの更新対象だけを許可する。
+      // 同じcache内のdart binaryやflutter_tools.snapshotはread-onlyのまま維持する。
+      "$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/engine.stamp",
+      "$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/engine.realm",
+      "$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/lockfile",
+      "$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/flutter_version_check.stamp",
+    ],
     "bypass_protection": [
       "$HOME/.config/gh",
       "$HOME/.config/gcloud",

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -14,6 +14,7 @@ test_publish_root="$test_config_root/host-artifact/public"
 test_claude_state_root="$test_config_root/claude-state"
 test_neovim_root="$test_config_root/neovim"
 test_agent_tool_state_root="$test_config_root/agent-tool-state"
+test_flutter_dart_root="$test_config_root/flutter-dart"
 profile_dir="$test_config_root/nono/profiles"
 mkdir -p \
   "$profile_dir" \
@@ -22,7 +23,11 @@ mkdir -p \
   "$test_neovim_root/config" \
   "$test_neovim_root/share" \
   "$test_neovim_root/state" \
-  "$test_agent_tool_state_root/wrangler"
+  "$test_agent_tool_state_root/wrangler" \
+  "$test_agent_tool_state_root/pub-cache" \
+  "$test_flutter_dart_root/dart-tool" \
+  "$test_flutter_dart_root/dart-server" \
+  "$test_flutter_dart_root/flutter-config"
 for source in "$source_profile_dir"/*.jsonc; do
   cp "$source" "$profile_dir/$(basename "$source")"
 done
@@ -65,6 +70,10 @@ for copied_profile in "$profile_dir"/*.jsonc; do
     -e 's|$HOME/.local/share/nvim|'"$test_neovim_root/share"'|g' \
     -e 's|$HOME/.local/state/nvim|'"$test_neovim_root/state"'|g' \
     -e 's|$HOME/.local/state/nono-agent-tools|'"$test_agent_tool_state_root"'|g' \
+    -e 's|$HOME/.dart-tool|'"$test_flutter_dart_root/dart-tool"'|g' \
+    -e 's|$HOME/.dartServer|'"$test_flutter_dart_root/dart-server"'|g' \
+    -e 's|$HOME/.config/flutter|'"$test_flutter_dart_root/flutter-config"'|g' \
+    -e 's|$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache|'"$test_flutter_dart_root/flutter-sdk-cache"'|g' \
     "$copied_profile" >"$rendered_profile"
   mv "$rendered_profile" "$copied_profile"
 done
@@ -420,6 +429,66 @@ test_common_profile_configures_sandbox_compatible_javascript_tools() {
     nix/modules/home/dotfiles.nix
 }
 
+test_common_profile_allows_flutter_and_dart_runtime_state_without_home_wide_access() {
+  local agent
+
+  # Arrange: Flutter 3.35.4 and Dart use shared package data plus three product-specific state roots.
+  # Act & Assert: Grant each runtime path only the mode required by standard generation, lint, and test commands.
+  assert_profile_value '.environment.set_vars.PUB_CACHE' '$HOME/.local/state/nono-agent-tools/pub-cache'
+  assert_profile_array_contains '.filesystem.allow' '$HOME/.local/state/nono-agent-tools/pub-cache'
+  assert_profile_array_contains '.filesystem.allow' '$HOME/.dart-tool'
+  assert_profile_array_contains '.filesystem.allow' '$HOME/.dartServer'
+  assert_profile_array_contains '.filesystem.allow' '$HOME/.config/flutter'
+  assert_profile_array_contains \
+    '.filesystem.allow_file' \
+    '$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/engine.stamp'
+  assert_profile_array_contains \
+    '.filesystem.allow_file' \
+    '$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/engine.realm'
+  assert_profile_array_contains \
+    '.filesystem.allow_file' \
+    '$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/lockfile'
+  assert_profile_array_contains \
+    '.filesystem.allow_file' \
+    '$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/flutter_version_check.stamp'
+
+  for agent in codex claude pi; do
+    assert_agent_path_decision \
+      "$agent" "ALLOWED" "$test_flutter_dart_root/dart-tool/dart-flutter-telemetry.log" "readwrite"
+    assert_agent_path_decision \
+      "$agent" "ALLOWED" "$test_agent_tool_state_root/pub-cache/hosted/pub.dev/example/package.dart" "readwrite"
+    assert_agent_path_decision \
+      "$agent" "ALLOWED" "$test_flutter_dart_root/dart-server/.analysis-driver" "readwrite"
+    assert_agent_path_decision \
+      "$agent" "ALLOWED" "$test_flutter_dart_root/flutter-config/tool_state" "readwrite"
+    assert_agent_path_decision \
+      "$agent" "ALLOWED" "$test_flutter_dart_root/flutter-sdk-cache/engine.stamp" "readwrite"
+    assert_agent_path_decision \
+      "$agent" "ALLOWED" "$test_flutter_dart_root/flutter-sdk-cache/engine.realm" "readwrite"
+    assert_agent_path_decision \
+      "$agent" "DENIED" "$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/flutter_tools.snapshot" "write"
+    assert_agent_path_decision \
+      "$agent" "DENIED" "$HOME/.local/share/mise/installs/flutter/3.35.4-stable/bin/cache/dart-sdk/bin/dart" "write"
+    assert_agent_path_decision \
+      "$agent" "DENIED" "$HOME/.local/share/mise/installs/flutter/3.32.6-stable/bin/cache/engine.stamp" "write"
+  done
+
+  # Assert: No parent directory broadens access to unrelated package, config, or mise installation data.
+  assert_profile_value '.filesystem.allow | index("$HOME") == null' 'true'
+  assert_profile_value '.filesystem.allow | index("$HOME/.config") == null' 'true'
+  assert_profile_value '.filesystem.allow | index("$HOME/.local/share/mise") == null' 'true'
+  assert_profile_value '.filesystem.read | index("$HOME/.pub-cache") == null' 'true'
+  assert_profile_value '.filesystem.allow_file | any(contains("/.git/FETCH_HEAD"))' 'false'
+
+  # Assert: Home Manager creates roots that nono must canonicalize before either tool can initialize them.
+  rg -q -F \
+    '$DRY_RUN_CMD mkdir -p "${homeDirectory}/.dart-tool" "${homeDirectory}/.dartServer" "${configHome}/flutter"' \
+    nix/modules/home/dotfiles.nix
+  rg -q -F \
+    '$DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/wrangler" "${homeDirectory}/.local/state/nono-agent-tools/pub-cache"' \
+    nix/modules/home/dotfiles.nix
+}
+
 test_command_policies_never_require_human_approval() {
   # Arrange: agent commandは対話待ちを発生させず、allowまたはdenyで即時決定する。
   # Act & Assert: approval backend、approve decision、default approveを一切持たない。
@@ -601,6 +670,7 @@ test_common_profile_denies_unconfigured_clouds
 test_common_profile_allows_all_ghq_repositories
 test_common_profile_allows_new_ghq_clone_destinations
 test_common_profile_configures_sandbox_compatible_javascript_tools
+test_common_profile_allows_flutter_and_dart_runtime_state_without_home_wide_access
 test_command_policies_never_require_human_approval
 test_container_wrapper_prefers_the_tool_sandbox_shim
 test_container_policy_allows_mysql_integration_test_lifecycle


### PR DESCRIPTION
## 概要

- Codex の nono sandbox 内で Flutter 3.35.4 / Dart の標準開発コマンドを実行可能にする
- SDK executable や credential、home 全体へ権限を広げず、観測済みの state/file/domain に限定する

## 変更内容

- Dart/Flutter の tool state と analysis server state を read/write 許可
- agent 専用の writable Pub cache を設定し、既存のグローバル cache から分離
- pub.dev を dependency resolution 用に許可
- Flutter SDK cache は更新が必要な stamp/lock/realm ファイルだけを許可
- Home Manager activation で capability root を事前作成
- Codex/Claude/Pi の allow/deny 境界を profile test に追加

## テスト

- bash tests/nono-profile.sh
- nono profile validate --strict nono/profiles/chouge-agent-common.jsonc
- nono profile validate --strict nono/profiles/chouge-codex.jsonc
- nix run .#build
- git diff --check
- mise run lint（sandbox 上で dependency 解決と analyzer 起動に成功。katohome-monorepo の未生成 .g.dart により lint error）
- mise run test（sandbox denial なし。katohome-monorepo の未生成 .g.dart により一部 compile error）
