### PR TITLE
docs(agents): Herdr初回命名の入口を追加する

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -21,6 +21,7 @@
 
 ## Workflows
 
+- セッションの最初の実質的なタスクに着手する前に `HERDR_ENV` を確認する。値が `1` なら `herdr` skill に従い、現在 agent の初回命名を判定する。
 - `CHANGES.md` の変更履歴では `chouge-changelog` skill に従う。
 - テストをレビューする場合は `test-writing-style` skill に従う。
 - agent skill の作成・改善を実装するときは `implement` skill を入口にし、その中で `skill-workbench` skill に従う。レビューだけを行う場合は `skill-workbench` skill を入口にする。


### PR DESCRIPTION
## 概要

- Herdr session の最初の実質的タスクで、初回命名を確実に判定できる入口を追加する

## 変更内容

- global `AGENTS.md` で最初の実質的タスク前に `HERDR_ENV` を確認する
- `HERDR_ENV=1` の場合だけ `herdr` skill へ初回命名を委譲する
- 命名規則やHerdr操作の詳細はskill側を正本として重複させない

## テスト

- `git diff --check`
