### PR TITLE
fix(nono): GitHub Actionsログ取得hostを許可する（マージ後反映要）

### DIFF
--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -83,9 +83,10 @@
       "sum.golang.org",
       // Dart/Flutter dependency resolution。
       "pub.dev",
-      // OpenAIの開発者向け文書とGitHub Releasesの成果物取得で利用する。
+      // OpenAIの開発者向け文書、GitHub Releases、GitHub Actionsのlog取得で利用する。
       "developers.openai.com",
       "release-assets.githubusercontent.com",
+      "results-receiver.actions.githubusercontent.com",
       // Google認証とcontainer registryで利用する。
       "accounts.google.com",
       "gcr.io",

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -371,6 +371,18 @@ test_common_profile_allows_development_endpoints() {
   done
 }
 
+test_common_profile_allows_github_actions_log_endpoint() {
+  # Arrange & Act: GitHub CLIがActionsのjob log取得でredirectされるHTTPS hostを評価する。
+  # Assert: 認証済みのgh run viewがlog archiveを取得できる。
+  assert_host_decision "ALLOWED" results-receiver.actions.githubusercontent.com
+}
+
+test_common_profile_does_not_allow_all_github_actions_hosts() {
+  # Arrange & Act: 許可したlog配信hostと同じ親domainの未設定hostを評価する。
+  # Assert: GitHub Actions配下をwildcardで許可せず、exact hostの境界を保つ。
+  assert_host_decision "DENIED" unrelated.actions.githubusercontent.com
+}
+
 test_common_profile_allows_tailscale_serve_origins() {
   # Arrange & Act: Evaluate a representative MagicDNS HTTPS origin without connecting to it.
   # Assert: Host-artifact can verify its Tailscale Serve URL through the parent sandbox.
@@ -665,6 +677,8 @@ test_common_profile_allows_only_the_chrome_bridge_socket_subtree
 test_common_profile_allows_only_the_nix_daemon_socket
 test_common_profile_uses_enterprise_network
 test_common_profile_allows_development_endpoints
+test_common_profile_allows_github_actions_log_endpoint
+test_common_profile_does_not_allow_all_github_actions_hosts
 test_common_profile_allows_tailscale_serve_origins
 test_common_profile_denies_unconfigured_clouds
 test_common_profile_allows_all_ghq_repositories


### PR DESCRIPTION
## 概要
- GitHub Actions の job log 配信先を nono の network allowlist に追加します。マージ後、Home Manager の反映と新しい agent pane の起動が必要です。

## 変更内容
- `results-receiver.actions.githubusercontent.com` を exact host で許可
- 対象 host の許可と、同じ親 domain の未設定 host が拒否される境界テストを追加

## テスト
- `bash tests/nono-profile.sh`
- `for profile_file in nono/profiles/*.jsonc; do nono profile validate --strict "$profile_file"; done`
- `git diff --check`

## マージ後の確認
- [ ] Home Manager を反映する
- [ ] 新しい agent pane で `gh run view 31491543815 --job 93780995878 --log-failed` が取得できることを確認する
