### PR TITLE
fix(nono): GitHub ActionsのBlobログ取得先を許可する（マージ後反映要）

### DIFF
--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -83,10 +83,12 @@
       "sum.golang.org",
       // Dart/Flutter dependency resolution。
       "pub.dev",
-      // OpenAIの開発者向け文書、GitHub Releases、GitHub Actionsのlog取得で利用する。
+      // OpenAIの開発者向け文書とGitHub Releasesの成果物取得で利用する。
       "developers.openai.com",
       "release-assets.githubusercontent.com",
+      // GitHub Actionsのlog取得に必要な公式の通信先。Blob側はshardが変わるためsuffixで許可する。
       "results-receiver.actions.githubusercontent.com",
+      "*.blob.core.windows.net",
       // Google認証とcontainer registryで利用する。
       "accounts.google.com",
       "gcr.io",

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -383,6 +383,24 @@ test_common_profile_does_not_allow_all_github_actions_hosts() {
   assert_host_decision "DENIED" unrelated.actions.githubusercontent.com
 }
 
+test_common_profile_allows_github_actions_blob_log_endpoint() {
+  # Arrange & Act: GitHub Actionsのlog archiveがredirectされるshard付きAzure Blob hostを評価する。
+  # Assert: shard名が変わっても公式のlog配信suffix配下なら取得できる。
+  assert_host_decision "ALLOWED" productionresultssa5.blob.core.windows.net
+}
+
+test_common_profile_does_not_allow_azure_blob_apex() {
+  # Arrange & Act: wildcard対象外のAzure Blob apexを評価する。
+  # Assert: subdomain用wildcardがapex自体へ権限を広げない。
+  assert_host_decision "DENIED" blob.core.windows.net
+}
+
+test_common_profile_does_not_allow_adjacent_azure_storage_suffix() {
+  # Arrange & Act: GitHub公式allowlistとは異なるAzure Storage suffixを評価する。
+  # Assert: Azure Storage全体ではなくBlob endpointだけを許可する。
+  assert_host_decision "DENIED" productionresultssa5.file.core.windows.net
+}
+
 test_common_profile_allows_tailscale_serve_origins() {
   # Arrange & Act: Evaluate a representative MagicDNS HTTPS origin without connecting to it.
   # Assert: Host-artifact can verify its Tailscale Serve URL through the parent sandbox.
@@ -679,6 +697,9 @@ test_common_profile_uses_enterprise_network
 test_common_profile_allows_development_endpoints
 test_common_profile_allows_github_actions_log_endpoint
 test_common_profile_does_not_allow_all_github_actions_hosts
+test_common_profile_allows_github_actions_blob_log_endpoint
+test_common_profile_does_not_allow_azure_blob_apex
+test_common_profile_does_not_allow_adjacent_azure_storage_suffix
 test_common_profile_allows_tailscale_serve_origins
 test_common_profile_denies_unconfigured_clouds
 test_common_profile_allows_all_ghq_repositories


### PR DESCRIPTION
## 概要
- GitHub Actions の job log が redirect される Azure Blob endpoint を許可します。マージ後、Home Manager の反映と新しい agent pane の起動が必要です。

## 変更内容
- GitHub 公式の通信要件に従い `*.blob.core.windows.net` を許可
- shard 付き log host の許可をテスト
- wildcard 対象外の apex と隣接する Azure Storage service suffix が拒否されることをテスト

## セキュリティ上の判断
- wildcard は任意の Azure Blob account への egress を許可する
- GitHub は log、artifact、cache の取得先として同 wildcard を公式に要求し、実際の redirect host も shard 付きで変動するため、この範囲を運用上の例外として許容する

## テスト
- `bash tests/nono-profile.sh`
- `for profile_file in nono/profiles/*.jsonc; do nono profile validate --strict "$profile_file"; done`
- `git diff --check`

## マージ後の確認
- [ ] Home Manager を反映する
- [ ] 新しい agent pane で `gh run view 31491543815 --job 93780995878 --log-failed` が取得できることを確認する
