### PR TITLE
chore(apm): Realtime prompt skill を追加する

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -39,3 +39,4 @@ dependencies:
     - path: ~/ghq/github.com/nananaman/skills/productivity/herdr
     - path: ~/ghq/github.com/nananaman/skills/productivity/host-artifact
     - path: ~/ghq/github.com/nananaman/skills/productivity/improve-agent-prompt
+    - path: ~/ghq/github.com/nananaman/skills/engineering/realtime-prompt-review


### PR DESCRIPTION
## 概要
- user-invoked の `realtime-prompt-review` skill をグローバル APM 依存に追加します。

## 変更内容
- `apm/apm.yml` に `~/ghq/github.com/nananaman/skills/engineering/realtime-prompt-review` を追加

## テスト
- `git diff --check`
- canonical skills checkout が `origin/main` の merge commit `5900aa50910d59361cdab32c1e08bc78a2b3abb0` と一致することを確認
- local path の `SKILL.md` が存在することを確認

## 適用
- `apm install -g` は未実行です。マージ後に user-scope manifest へ反映して実行します。
