### PR TITLE
chore(nix): docker 一式を Homebrew 宣言へ追加し buildx を CLI plugin として配置する

### DIFF
--- a/nix/modules/darwin/system.nix
+++ b/nix/modules/darwin/system.nix
@@ -71,6 +71,11 @@
 
     brews = [
       "container"
+      "docker"
+      "docker-compose"
+      # credsStore = osxkeychain を解決する docker-credential-osxkeychain を提供する
+      "docker-credential-helper"
+      "docker-buildx"
     ];
 
     casks = [

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -62,6 +62,12 @@ in
     link_force "${dotfilesDir}/stylua.toml" "${configHome}/stylua.toml"
     link_force "${dotfilesDir}/srt" "${configHome}/srt"
 
+    ${lib.optionalString pkgs.stdenv.isDarwin ''
+      # Homebrew の docker-buildx は cli-plugins へ自分で配置する必要がある
+      $DRY_RUN_CMD mkdir -p "${homeDirectory}/.docker/cli-plugins"
+      link_force "/opt/homebrew/opt/docker-buildx/bin/docker-buildx" "${homeDirectory}/.docker/cli-plugins/docker-buildx"
+    ''}
+
     $DRY_RUN_CMD mkdir -p "${configHome}/nono/profiles"
     $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/wrangler" "${homeDirectory}/.local/state/nono-agent-tools/pub-cache"
     $DRY_RUN_CMD mkdir -p "${homeDirectory}/.dart-tool" "${homeDirectory}/.dartServer" "${configHome}/flutter"


### PR DESCRIPTION
## 背景

`homebrew.onActivation.cleanup = "uninstall"` を設定しているため、`brews` に宣言していない formula は `nix run .#switch` のたびにアンインストールされる。

手動で `brew install` した docker 関連が繰り返し消えており、`docker-credential-osxkeychain` が不在の状態で `docker compose build` が次のエラーで失敗していた。

```
error listing credentials - err: exec: "docker-credential-osxkeychain": executable file not found in $PATH
```

`~/.docker/config.json` の `credsStore: osxkeychain` は残っているが、Docker Desktop 未インストールのためヘルパー実体が無い、という状態だった。

## 変更

- `nix/modules/darwin/system.nix`: `homebrew.brews` に `docker` / `docker-compose` / `docker-credential-helper` / `docker-buildx` を追加
- `nix/modules/home/dotfiles.nix`: Homebrew 版 `docker-buildx` を `~/.docker/cli-plugins/docker-buildx` へ symlink（darwin 限定、既存の `link_force` パターン）

buildx は Homebrew 版 docker に同梱されず、`cli-plugins` への配置も nix-darwin の homebrew module では行われないため、symlink は自前で張る必要がある。

## 検証

- `nixfmt` 適用済み（追加整形なし）
- `nix run .#build` 成功
- ビルド生成物を確認
  - Brewfile に 4 つの formula が出力されている
  - home-manager の `activate` に `mkdir -p ~/.docker/cli-plugins` と buildx への `link_force` が展開されている
- `darwinConfigurations` の `chouge` / `juntawatanabe` は同じモジュールを共有するため、片方のみ buildx 未インストールで dangling symlink になることはない

## 残作業

- [ ] `nix run .#switch` を適用し、`docker buildx version` が通ることを確認する（AGENTS.md の規定により本 PR では未実行）
