### PR TITLE
fix(nono): Seatbelt の TMPDIR socket 許可を /private 付き物理パスにする

### DIFF
--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -35,7 +35,8 @@
     // terraform providerなどgo-pluginベースのツールは起動ごとにTMPDIR配下へ
     // ランダムな名前のunix domain socketを作りRPC通信する(例: /var/folders/.../T/pluginNNNNNN)。
     // socket名が実行ごとに変わり個別に許可できないため、TMPDIR配下への接続を広めに許可する。
-    "(allow network-outbound (subpath \"/var/folders/8j/pnlb6lnn6wg7dm420zyv5wj80000gp/T\"))",
+    // /varは/private/varへのsymlinkで、Seatbeltは解決後の物理パスで照合するため/private付きで書く。
+    "(allow network-outbound (subpath \"/private/var/folders/8j/pnlb6lnn6wg7dm420zyv5wj80000gp/T\"))",
     // host-artifactは親sandboxから固定serviceとTailscale daemonだけを利用する。
     "(allow network-outbound (remote tcp \"localhost:9417\"))",
     "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))",


### PR DESCRIPTION
## 概要

`nono/profiles/chouge-agent-common.jsonc` の `unsafe_macos_seatbelt_rules` にある TMPDIR 配下の `network-outbound` 許可が効いていなかったため、パスを `/private` 付きの物理パスへ修正する。

## 背景

- macOS の `/var` は `/private/var` への symlink で、Seatbelt は解決後の物理パスで照合する。
- `unsafe_macos_seatbelt_rules` は profile schema の記述どおり verbatim に適用され、nono 側の正規化も入らない。
- 結果として `/var/folders/.../T` と書いた subpath ルールはどの接続にもマッチしていなかった。
- 同じ配列の近傍ルール(`/private/var/run/nix-daemon.socket`、`/private/tmp/codex-browser-use`)は `/private` 付きで、この行だけが漏れていた。

実測での切り分け(nono 0.68.0):

1. TMPDIR 配下に unix socket を bind + listen → 成功
2. 同じ socket へ connect → `PermissionError: Operation not permitted`
3. `/private/tmp/codex-browser-use` 配下(= `/private` 付き subpath ルールの配下)へ connect → 成功

terraform では `TF_LOG=trace` で `dial unix /var/folders/.../T/pluginNNNNNN: connect: operation not permitted` となり、`Failed to load plugin schemas` で `validate` / `plan` が失敗していた。

## 変更内容

- `subpath` を `/private/var/folders/8j/pnlb6lnn6wg7dm420zyv5wj80000gp/T` に変更。
- `/private` が必要な理由をコメントで併記。

もともと意図されていた範囲が効くようになるだけで、権限は広がらない。

## 検証

- `nono profile validate --strict nono/profiles/chouge-agent-common.jsonc` → valid(既存の `container` 向け unsafe rule 警告 1 件のみ、本変更とは無関係)

## 残作業

反映には新しい nono session が必要(`NONO_CAP_FILE` は session 開始時に確定する)。

- [ ] merge と適用後、新しい session で `terraform validate` / `plan` が通ることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)