### PR TITLE
fix(nono): Terraform provider配布先を許可する（merge後にswitch必須）

### DIFF
--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -81,6 +81,10 @@
       "*.anthropic.com",
       "proxy.golang.org",
       "sum.golang.org",
+      // Terraform providerのservice discoveryとregistry protocol API。
+      "registry.terraform.io",
+      // HashiCorp providerのarchive、checksum、signature配布先。
+      "releases.hashicorp.com",
       // Dart/Flutter dependency resolution。
       "pub.dev",
       // OpenAIの開発者向け文書とGitHub Releasesの成果物取得で利用する。

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -371,6 +371,34 @@ test_common_profile_allows_development_endpoints() {
   done
 }
 
+test_common_profile_allows_only_the_terraform_provider_distribution_endpoints() {
+  # Arrange & Act: Terraform providerのservice discovery先、配布先、隣接hostを評価する。
+  # Assert: 公式配布のexact hostだけを共通profileから利用できる。
+  assert_host_decision "ALLOWED" registry.terraform.io
+  assert_host_decision "ALLOWED" releases.hashicorp.com
+  assert_host_decision "DENIED" attacker.registry.terraform.io
+  assert_host_decision "DENIED" unrelated.terraform.io
+  assert_host_decision "DENIED" attacker.releases.hashicorp.com
+  assert_host_decision "DENIED" unrelated.hashicorp.com
+}
+
+test_agent_profiles_inherit_terraform_provider_distribution_endpoints() {
+  local agent
+  local host
+  local output
+
+  # Arrange: 共通network policyを継承し、固有domainも追加する全agent profileを使う。
+  for agent in codex claude pi; do
+    for host in registry.terraform.io releases.hashicorp.com; do
+      # Act: 合成後のprofileでTerraform provider配布hostを評価する。
+      output="$(nono why --profile "$profile_dir/chouge-$agent.jsonc" --host "$host" --port 443)"
+
+      # Assert: agent固有のnetwork設定が共通の配布許可を上書きしない。
+      [[ "${output%%$'\n'*}" == "ALLOWED" ]] || return 1
+    done
+  done
+}
+
 test_common_profile_allows_github_actions_log_endpoint() {
   # Arrange & Act: GitHub CLIがActionsのjob log取得でredirectされるHTTPS hostを評価する。
   # Assert: 認証済みのgh run viewがlog archiveを取得できる。
@@ -695,6 +723,8 @@ test_common_profile_allows_only_the_chrome_bridge_socket_subtree
 test_common_profile_allows_only_the_nix_daemon_socket
 test_common_profile_uses_enterprise_network
 test_common_profile_allows_development_endpoints
+test_common_profile_allows_only_the_terraform_provider_distribution_endpoints
+test_agent_profiles_inherit_terraform_provider_distribution_endpoints
 test_common_profile_allows_github_actions_log_endpoint
 test_common_profile_does_not_allow_all_github_actions_hosts
 test_common_profile_allows_github_actions_blob_log_endpoint


### PR DESCRIPTION
## 概要

この変更は merge だけでは有効になりません。merge 後に利用者が `nix run .#switch` を実行し、Codex を再起動する必要があります。

- coding agent が通常の `terraform init` / test で HashiCorp provider を取得できるよう、共通 nono profile の最小ネットワーク許可を追加します。
- Terraform の remote service discovery と Provider Registry Protocol、および package lookup の公式配布先を根拠に exact host だけを許可します。

## 変更内容

- `chouge-agent-common` に次の exact host を追加
  - `registry.terraform.io`: service discovery と provider registry API
  - `releases.hashicorp.com`: provider archive、checksum、signature
- wildcard、隣接 host、子 host を許可しない境界テストを追加
- Codex / Claude / Pi が共通許可を継承することをテスト

## テスト

- `bash tests/nono-profile.sh`
- `nono profile validate --strict nono/profiles/chouge-agent-common.jsonc`
- `nono profile validate --strict nono/profiles/chouge-codex.jsonc`
- `nono profile validate --strict nono/profiles/chouge-claude.jsonc`
- `nono profile validate --strict nono/profiles/chouge-pi.jsonc`
- `nono profile diff chouge-agent-common nono/profiles/chouge-agent-common.jsonc`
- `nono why` による許可 host / 隣接 host / 子 host の境界確認
- `git diff --check`

更新 profile を明示した `nono run` 内の `terraform init -backend=false` は未実行です。現在の Codex session に旧 profile の `NONO_CAP_FILE` が注入済みで、nested sandbox を起動できないためです。旧 profile 下では `registry.terraform.io/.well-known/terraform.json` への実通信が 403 `proxy_filtered` になることを再現済みです。

## Merge 後の作業

- [ ] `nix run .#switch` を実行して生成 profile を更新する
- [ ] Codex を再起動して新しい Tool Sandbox profile を読み込む
- [ ] 一時 directory で `terraform init -backend=false` の fresh provider download を確認する
