### PR TITLE
fix(nono): Unix socket用TMPDIRを固定する（merge後に適用が必要）

### DIFF
--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -70,6 +70,9 @@ in
 
     $DRY_RUN_CMD mkdir -p "${configHome}/nono/profiles"
     $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/wrangler" "${homeDirectory}/.local/state/nono-agent-tools/pub-cache"
+    ${lib.optionalString pkgs.stdenv.isDarwin ''
+      $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/tmp"
+    ''}
     $DRY_RUN_CMD mkdir -p "${homeDirectory}/.dart-tool" "${homeDirectory}/.dartServer" "${configHome}/flutter"
     for legacy_profile in chouge-agent-common chouge-codex chouge-claude chouge-pi; do
       legacy_path="${configHome}/nono/profiles/$legacy_profile.json"

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -32,11 +32,10 @@
     "(allow network-outbound (path \"@HOME@/ghq/github.com/nananaman/dotfiles/herdr/herdr.sock\"))",
     // Chrome bridgeは起動ごとに生成されるnative host socketで通信する。
     "(allow network-outbound (subpath \"/private/tmp/codex-browser-use\"))",
-    // terraform providerなどgo-pluginベースのツールは起動ごとにTMPDIR配下へ
-    // ランダムな名前のunix domain socketを作りRPC通信する(例: /var/folders/.../T/pluginNNNNNN)。
-    // socket名が実行ごとに変わり個別に許可できないため、TMPDIR配下への接続を広めに許可する。
-    // /varは/private/varへのsymlinkで、Seatbeltは解決後の物理パスで照合するため/private付きで書く。
-    "(allow network-outbound (subpath \"/private/var/folders/8j/pnlb6lnn6wg7dm420zyv5wj80000gp/T\"))",
+    // terraform providerなどgo-pluginベースのツールが作るランダム名のUnix socketは、
+    // agent専用TMPDIRの内側だけでbindと接続を許可する。
+    "(allow network-bind (subpath \"@HOME@/.local/state/nono-agent-tools/tmp\"))",
+    "(allow network-outbound (subpath \"@HOME@/.local/state/nono-agent-tools/tmp\"))",
     // host-artifactは親sandboxから固定serviceとTailscale daemonだけを利用する。
     "(allow network-outbound (remote tcp \"localhost:9417\"))",
     "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))",
@@ -163,7 +162,14 @@
   },
   "platform_overrides": {
     "macos": {
+      "environment": {
+        "set_vars": {
+          // go-pluginなどが作るUnix socketをuser/session固有のmacOS TMPDIRから分離する。
+          "TMPDIR": "$HOME/.local/state/nono-agent-tools/tmp",
+        },
+      },
       "filesystem": {
+        "allow": ["$HOME/.local/state/nono-agent-tools/tmp"],
         "read": ["$HOME/.vite-plus"],
         "write_file": [
           "$HOME/.vite-plus/cache/resolve_cache.json",

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -351,6 +351,26 @@ test_common_profile_allows_only_the_nix_daemon_socket() {
   [[ "${output%%$'\n'*}" == "DENIED" ]] || return 1
 }
 
+test_common_profile_uses_a_dedicated_agent_tmpdir_for_unix_sockets() {
+  # Arrange: go-pluginはTMPDIR直下にランダム名のUnix socketを作る。
+  # Act & Assert: agent専用TMPDIRだけを使い、macOSのuser/session固有pathへ依存しない。
+  assert_profile_value \
+    '.platform_overrides.macos.environment.set_vars.TMPDIR' \
+    '$HOME/.local/state/nono-agent-tools/tmp'
+  assert_profile_value \
+    '.platform_overrides.macos.filesystem.allow | index("$HOME/.local/state/nono-agent-tools/tmp") != null' \
+    'true'
+  assert_profile_value \
+    '.environment.set_vars | has("TMPDIR")' \
+    'false'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("nono-agent-tools/tmp"))] | tojson' \
+    '["(allow network-bind (subpath \"@HOME@/.local/state/nono-agent-tools/tmp\"))","(allow network-outbound (subpath \"@HOME@/.local/state/nono-agent-tools/tmp\"))"]'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("/private/var/folders"))] | length' \
+    '0'
+}
+
 test_common_profile_uses_enterprise_network() {
   assert_profile_value \
     '.network.network_profile' \
@@ -721,6 +741,7 @@ test_common_profile_allows_claude_lock_state_without_broad_state_access
 test_common_profile_keeps_chrome_data_outside_direct_agent_access
 test_common_profile_allows_only_the_chrome_bridge_socket_subtree
 test_common_profile_allows_only_the_nix_daemon_socket
+test_common_profile_uses_a_dedicated_agent_tmpdir_for_unix_sockets
 test_common_profile_uses_enterprise_network
 test_common_profile_allows_development_endpoints
 test_common_profile_allows_only_the_terraform_provider_distribution_endpoints


### PR DESCRIPTION
## 概要

- macOS のユーザー・セッション固有 `TMPDIR` を Seatbelt rule に固定せず、nono agent 専用の安定した `TMPDIR` を使うようにする
- merge だけでは現在の profile と実行中 session は更新されないため、merge 後の switch と Codex 再起動が必要

## 変更内容

- macOS の `platform_overrides` で `TMPDIR=$HOME/.local/state/nono-agent-tools/tmp` を設定
- 専用 TMPDIR の filesystem access と、その subtree 内だけの Unix socket `network-bind` / `network-outbound` を許可
- `/private/var/folders/<user/session>/T` に固定した既存 rule を削除
- activation で macOS の専用 TMPDIR を事前作成
- 専用 directory、macOS 限定、旧 `/private/var/folders` rule の不在を focused test で固定
- `checkpoint-api.hashicorp.com` は許可対象に追加しない

## テスト

- `bash tests/nono-profile.sh`
- `nono profile validate --strict nono/profiles/chouge-agent-common.jsonc`
- `nono profile validate --strict nono/profiles/chouge-codex.jsonc`
- `nono profile validate --strict nono/profiles/chouge-claude.jsonc`
- `nono profile validate --strict nono/profiles/chouge-pi.jsonc`
- `nix run .#build`
- `nono profile diff <origin/main profile> nono/profiles/chouge-agent-common.jsonc`
- `git diff --check`
- 更新済み生成 profile を明示した外側 nono session で、一時 Terraform fixture の `init` と `validate` を実行
  - `hashicorp/null` provider の schema RPC (`GetProviderSchema`, `ValidateResourceTypeConfig`) が成功
  - `CHECKPOINT_DISABLE=1` を指定し、外部 state と credential は未使用

## merge 後の残作業

- [ ] `nix run .#switch` で生成 profile と activation を適用する
- [ ] Codex を再起動し、新しい nono session へ切り替える
