### PR TITLE
feat(codex): Herdrタブのタイトルを自動生成する

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -1,0 +1,8 @@
+# Codex hooks
+
+`hooks.json` is the declarative source of truth for Codex hooks.
+
+`herdr-agent-state.sh` is vendored from `herdr integration install codex` at the Herdr version pinned in `flake.lock`.
+When updating Herdr, generate the integration in a temporary home directory and replace this file with the generated script.
+
+`herdr-auto-title.py` is not vendored here. Home Manager installs it directly from the `herdr-auto-title` Flake input pinned in `flake.lock`.

--- a/codex/herdr-agent-state.sh
+++ b/codex/herdr-agent-state.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=codex
+# HERDR_INTEGRATION_VERSION=6
+
+set -eu
+
+action="${1:-}"
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-codex-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+case "$action" in
+  session) ;;
+  *) exit 0 ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:codex"
+action = os.environ.get("HERDR_ACTION", "")
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+hook_event_name = str(hook_input.get("hook_event_name") or "")
+if hook_event_name and hook_event_name != "SessionStart":
+    raise SystemExit(0)
+
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+session_id = hook_input.get("session_id")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+session_start_source = hook_input.get("source") if hook_event_name == "SessionStart" else None
+if not isinstance(session_start_source, str) or not session_start_source:
+    session_start_source = None
+if agent_session_id:
+    params = {
+        "pane_id": pane_id,
+        "source": source,
+        "agent": "codex",
+        "seq": report_seq,
+        "agent_session_id": agent_session_id,
+    }
+    if session_start_source:
+        params["session_start_source"] = session_start_source
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent_session",
+        "params": params,
+    }
+else:
+    raise SystemExit(0)
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY

--- a/codex/hooks.json
+++ b/codex/hooks.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bash \"$HOME/.codex/herdr-agent-state.sh\" session",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"$HOME/.codex/hooks/herdr-auto-title.py\"",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -120,6 +120,23 @@
         "type": "github"
       }
     },
+    "herdr-auto-title": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786590199,
+        "narHash": "sha256-XeH09xrbgPfR2RiWGbVtu1G55gkE/k+L6PFwvQIZTsg=",
+        "owner": "sh1ma",
+        "repo": "herdr-auto-title",
+        "rev": "7e5aeebadac9f04f4b343d206af8f406249c124d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sh1ma",
+        "repo": "herdr-auto-title",
+        "rev": "7e5aeebadac9f04f4b343d206af8f406249c124d",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -263,6 +280,7 @@
         "codex-cli-nix": "codex-cli-nix",
         "flake-parts": "flake-parts",
         "herdr": "herdr",
+        "herdr-auto-title": "herdr-auto-title",
         "home-manager": "home-manager",
         "hunk": "hunk",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    herdr-auto-title = {
+      url = "github:sh1ma/herdr-auto-title/7e5aeebadac9f04f4b343d206af8f406249c124d";
+      flake = false;
+    };
+
     hunk = {
       url = "github:modem-dev/hunk";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -184,6 +189,7 @@
                               dotfilesDir
                               ;
                             herdrPackage = herdr.packages.${pkgs.system}.default;
+                            herdrAutoTitleInput = inputs.herdr-auto-title;
                             hunkInput = hunk;
                             codexCliPackage = codex-cli-nix.packages.${pkgs.system}.codex;
                           })
@@ -222,6 +228,7 @@
                         dotfilesDir
                         ;
                       herdrPackage = herdr.packages.${pkgs.system}.default;
+                      herdrAutoTitleInput = inputs.herdr-auto-title;
                       hunkInput = hunk;
                       codexCliPackage = codex-cli-nix.packages.${pkgs.system}.codex;
                     })

--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -5,6 +5,7 @@
   helpers,
   dotfilesDir,
   herdrPackage,
+  herdrAutoTitleInput,
   hunkInput,
   codexCliPackage,
   ...
@@ -26,6 +27,7 @@
         config
         dotfilesDir
         helpers
+        herdrAutoTitleInput
         hunkInput
         ;
     })

--- a/nix/modules/home/programs/codex.nix
+++ b/nix/modules/home/programs/codex.nix
@@ -1,0 +1,27 @@
+{
+  pkgs,
+  config,
+  dotfilesDir,
+  herdrAutoTitleInput,
+  ...
+}:
+{
+  home.packages = [ pkgs.python3 ];
+
+  home.file = {
+    ".codex/hooks.json" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/codex/hooks.json";
+      force = true;
+    };
+
+    ".codex/hooks/herdr-auto-title.py" = {
+      source = "${herdrAutoTitleInput}/herdr_auto_title.py";
+      executable = true;
+    };
+
+    ".codex/herdr-agent-state.sh" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/codex/herdr-agent-state.sh";
+      force = true;
+    };
+  };
+}

--- a/nix/modules/home/programs/default.nix
+++ b/nix/modules/home/programs/default.nix
@@ -2,6 +2,7 @@
   pkgs,
   config,
   dotfilesDir,
+  herdrAutoTitleInput,
   hunkInput,
   ...
 }:
@@ -9,6 +10,14 @@
   imports = [
     ./git.nix
     (import ./agent-instructions.nix { inherit config dotfilesDir; })
+    (import ./codex.nix {
+      inherit
+        pkgs
+        config
+        dotfilesDir
+        herdrAutoTitleInput
+        ;
+    })
     (import ./hunk.nix { inherit pkgs hunkInput; })
     ./starship.nix
     (import ./claude-code.nix { inherit config dotfilesDir; })


### PR DESCRIPTION
## 概要
- Codex のユーザー入力から Herdr tab の短いタイトルを初回だけ自動生成する hook を宣言的に導入します。

## 変更内容
- `sh1ma/herdr-auto-title` を full SHA で Flake input に固定しました。
- `UserPromptSubmit` hook と既存の Herdr `SessionStart` hook を `codex/hooks.json` で一元管理します。
- hook 本体、Python 3、Herdr agent-state integration を Home Manager で配布します。
- Herdr integration script の更新方法を `codex/README.md` に記録しました。

## テスト
- `nix run .#build`
- `jq empty codex/hooks.json`
- `sh -n codex/herdr-agent-state.sh`
- `python3 ~/.codex/hooks/herdr-auto-title.py --version`
- `nix run .#switch` 後に `UserPromptSubmit` hook と配布ファイルを実環境で確認
