### PR TITLE
fix(nono): Chrome拡張連携のbridge domainを許可する

### DIFF
--- a/nono/profiles/chouge-claude.jsonc
+++ b/nono/profiles/chouge-claude.jsonc
@@ -13,6 +13,9 @@
       "*.cloud.langfuse.com",
       // EU regionだけsubdomainが無くwildcardで拾えないため個別に許可する。
       "cloud.langfuse.com",
+      // Claude in Chrome拡張とのMCP通信は、wss://bridge.claudeusercontent.com/chrome/への
+      // relay接続だけで成立する。staging bridgeや同apexの他serviceへは広げない。
+      "bridge.claudeusercontent.com",
     ],
     // Claude OAuth login starts a localhost callback server on an ephemeral port.
     "open_port": [0]

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -745,10 +745,19 @@ test_claude_allows_login_endpoints_and_launch_services() {
   assert_agent_profile_value \
     claude \
     '.network.allow_domain | tojson' \
-    '["claude.com"]'
+    '["claude.com","*.cloud.langfuse.com","cloud.langfuse.com","bridge.claudeusercontent.com"]'
   assert_agent_profile_value claude '.network.open_port | tojson' '[0]'
   assert_agent_profile_value claude '.allow_launch_services' 'null'
   rg -q -- '--allow-launch-services' nix/modules/home/packages.nix
+}
+
+test_claude_allows_only_the_chrome_extension_bridge_host() {
+  # Arrange: claude-in-chromeのMCP toolは、wss://bridge.claudeusercontent.com/chrome/への
+  # relay接続だけでChrome拡張と通信する。
+  # Act & Assert: exact hostだけを許可し、staging bridgeや同apexの他serviceへは広げない。
+  assert_agent_host_decision claude ALLOWED bridge.claudeusercontent.com 443
+  assert_agent_host_decision claude DENIED bridge-staging.claudeusercontent.com 443
+  assert_agent_host_decision claude DENIED claudeusercontent.com 443
 }
 
 test_claude_wrapper_runs_self_update_outside_the_sandbox() {
@@ -819,6 +828,7 @@ test_codex_injects_the_session_ca_for_python_https_clients
 test_codex_observability_does_not_allow_adjacent_hosts
 test_claude_allows_anthropic_api_endpoint
 test_claude_allows_login_endpoints_and_launch_services
+test_claude_allows_only_the_chrome_extension_bridge_host
 test_claude_wrapper_runs_self_update_outside_the_sandbox
 test_claude_wrapper_self_update_bypass_requires_exactly_one_argument
 test_pi_allows_configured_openai_codex_endpoint


### PR DESCRIPTION
## 事象

nono ラッパー経由で起動した Claude Code では、Chrome 拡張連携 (`mcp__claude-in-chrome__*`) が常に `Browser extension is not connected` になっていた。nono を通さず `~/.local/bin/claude` を直接起動すると同じ呼び出しが成功する。

## 原因

claude-in-chrome の MCP tool は、ローカル socket やポートではなく `wss://bridge.claudeusercontent.com/chrome/<id>` へのクラウド relay 接続で拡張と通信する。WebSocket client は proxy 環境変数を尊重するため、nono の proxy domain filter が判定点になるが、この host が `chouge-claude` の allowlist に無く CONNECT が 403 で切られていた。

```
$ nono why --profile chouge-claude.jsonc --host bridge.claudeusercontent.com --port 443
DENIED
  Reason: proxy_filtered
  Details: Domain filtering is active. host bridge.claudeusercontent.com is not in the allowlist
```

## 変更

`chouge-claude` の `allow_domain` に exact host 1 件を追加する。

同時に観測できた `~/Library/Application Support/Google/Chrome/*/Extensions` の走査拒否は追加していない。この走査は拡張の導入検出を best-effort で行うだけで例外も catch されるため bridge 接続の gate ではなく、`deny_browser_data_macos` の境界を維持する。staging bridge と同 apex の他 service も許可対象にしていない。

`tests/nono-profile.sh` の `allow_domain` 完全一致 assertion は langfuse domain 追加の時点から失敗していたため、あわせて現状の宣言へ更新した。

## 検証

`nono profile validate --strict`(chouge-claude / chouge-agent-common) は既存の container Seatbelt warning のみで valid。`bash tests/nono-profile.sh` は exit 0。`nono profile diff` の追加は `+ allow_domain bridge.claudeusercontent.com` の 1 件のみ。

境界 (`nono why --host <host> --port 443`):

| host | 判定 |
| --- | --- |
| `bridge.claudeusercontent.com` | ALLOWED |
| `bridge-staging.claudeusercontent.com` | DENIED |
| `claudeusercontent.com` | DENIED |
| `evil.bridge.claudeusercontent.com` | DENIED |

sandbox 外から本 branch の profile と現行 profile を対照した runtime 検証:

```
=== 現行 profile ===
Browser extension is not connected. Please ensure the Claude browser extension is installed and running (...)

=== 本 branch の profile ===
[{"deviceId":"...","name":"Browser 1","osPlatform":"macOS","connectedAt":...,"isLocal":true}]
```

`~/.config/nono/profiles/chouge-claude.jsonc` は main checkout への out-of-store symlink なので、merge 後は新しい `claude` 起動から有効になる。`nix run .#build` / `switch` は不要。

## 対象外

nono 内で観測した `osascript` の Apple Events `-600` と `ps` の `operation not permitted` は本 PR の対象外で、未解決のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
