### PR TITLE
fix(nono): Langfuseの接続許可をagent共通にする

### DIFF
--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -97,6 +97,10 @@
       "accounts.google.com",
       "gcr.io",
       "*.pkg.dev",
+      // Langfuse Cloudのトレース・スコア参照と評価者定義の同期。regionごとにhostが分かれる。
+      "*.cloud.langfuse.com",
+      // EU regionだけsubdomainが無くwildcardで拾えないため個別に許可する。
+      "cloud.langfuse.com",
       // host-artifactが検証済みTailscale Serve URLを返すために利用する。
       "*.ts.net",
       // hatena

--- a/nono/profiles/chouge-claude.jsonc
+++ b/nono/profiles/chouge-claude.jsonc
@@ -9,10 +9,6 @@
   "network": {
     "allow_domain": [
       "claude.com",
-      // Langfuse Cloudのトレース・スコア参照と評価者定義の同期。regionごとにhostが分かれる。
-      "*.cloud.langfuse.com",
-      // EU regionだけsubdomainが無くwildcardで拾えないため個別に許可する。
-      "cloud.langfuse.com",
       // Claude in Chrome拡張とのMCP通信は、wss://bridge.claudeusercontent.com/chrome/への
       // relay接続だけで成立する。staging bridgeや同apexの他serviceへは広げない。
       "bridge.claudeusercontent.com",

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -411,6 +411,21 @@ test_common_profile_allows_development_endpoints() {
   done
 }
 
+test_agent_profiles_inherit_langfuse_cloud_endpoints() {
+  local agent
+
+  # Arrange: Langfuse integration is available to every local coding agent through the common profile.
+  for agent in codex claude pi; do
+    # Act & Assert: Regional subdomains and the EU apex are allowed after profile composition.
+    assert_agent_host_decision "$agent" "ALLOWED" "us.cloud.langfuse.com" 443
+    assert_agent_host_decision "$agent" "ALLOWED" "cloud.langfuse.com" 443
+
+    # Act & Assert: The grant does not extend to adjacent Langfuse domains.
+    assert_agent_host_decision "$agent" "DENIED" "langfuse.com" 443
+    assert_agent_host_decision "$agent" "DENIED" "attacker.langfuse.com" 443
+  done
+}
+
 test_common_profile_allows_only_the_terraform_provider_distribution_endpoints() {
   # Arrange & Act: Terraform providerのservice discovery先、配布先、隣接hostを評価する。
   # Assert: 公式配布のexact hostだけを共通profileから利用できる。
@@ -745,7 +760,7 @@ test_claude_allows_login_endpoints_and_launch_services() {
   assert_agent_profile_value \
     claude \
     '.network.allow_domain | tojson' \
-    '["claude.com","*.cloud.langfuse.com","cloud.langfuse.com","bridge.claudeusercontent.com"]'
+    '["claude.com","bridge.claudeusercontent.com"]'
   assert_agent_profile_value claude '.network.open_port | tojson' '[0]'
   assert_agent_profile_value claude '.allow_launch_services' 'null'
   rg -q -- '--allow-launch-services' nix/modules/home/packages.nix
@@ -798,6 +813,7 @@ test_common_profile_allows_only_the_nix_daemon_socket
 test_common_profile_uses_a_dedicated_agent_tmpdir_for_unix_sockets
 test_common_profile_uses_enterprise_network
 test_common_profile_allows_development_endpoints
+test_agent_profiles_inherit_langfuse_cloud_endpoints
 test_common_profile_allows_only_the_terraform_provider_distribution_endpoints
 test_agent_profiles_inherit_terraform_provider_distribution_endpoints
 test_common_profile_allows_github_actions_log_endpoint


### PR DESCRIPTION
## 概要

- Langfuse Cloudへの接続許可をClaude固有profileからagent共通profileへ移します。

## 変更内容

- `*.cloud.langfuse.com` と `cloud.langfuse.com` を `chouge-agent-common` で許可
- Claude固有profileからLangfuseの許可を削除
- Codex、Claude、Piで継承後の許可と隣接domainの拒否を検証するテストを追加

## テスト

- `bash tests/nono-profile.sh`
- `nono profile validate --strict nono/profiles/chouge-agent-common.jsonc`
- `nono profile validate --strict nono/profiles/chouge-codex.jsonc`
- `nono profile validate --strict nono/profiles/chouge-claude.jsonc`
- `nono profile validate --strict nono/profiles/chouge-pi.jsonc`
- `nix run .#build`
- `git diff --check`
