### PR TITLE
chore: apm と codex のバージョンを更新する

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -1,6 +1,8 @@
 name: chouge-agent-context
 version: 0.1.0
-target: claude,agent-skills
+targets:
+  - claude
+  - agent-skills
 
 dependencies:
   apm:

--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1786067426,
-        "narHash": "sha256-Qvi7ZJ9MpkUXdeu+zjxYkR92BIvwqp7LpqxbnZzVTOg=",
+        "lastModified": 1787535200,
+        "narHash": "sha256-qDi3utpYi4LnJvxtJN92EIVXLUfrjjX2kQJ3OKULiwg=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "edc92332229d4e8c658f5f2fda3a8e29280e8a1a",
+        "rev": "05b1b39da135e34526f898600e09e67b55d5436c",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785747939,
-        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
+        "lastModified": 1787364730,
+        "narHash": "sha256-NcYt9QJfpJiF1lAyN8BDPB4EeScbPU+EwQqPiBElrpU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
+        "rev": "a831408e6378bc02ebf8cc09b52c96ca86f6bab4",
         "type": "github"
       },
       "original": {

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -136,12 +136,12 @@ let
     export CODEX_EXECUTABLE_PATH="$HOME/${agent-wrapper-dir}/codex"
     export DISABLE_AUTOUPDATER=1
     if [ -n "''${NONO_CAP_FILE:-}" ]; then
-      exec ${codexCliPackage}/bin/codex-raw --sandbox danger-full-access --ask-for-approval never "$@"
+      exec ${codexCliPackage}/libexec/codex --sandbox danger-full-access --ask-for-approval never "$@"
     fi
     HERDR_AGENT=codex exec ${nono-cli}/bin/nono run --silent \
       --profile "$HOME/.config/nono/profiles/chouge-codex.jsonc" --allow-cwd -- \
       ${codex-nono-guard} \
-      ${codexCliPackage}/bin/codex-raw --sandbox danger-full-access --ask-for-approval never "$@"
+      ${codexCliPackage}/libexec/codex --sandbox danger-full-access --ask-for-approval never "$@"
   '';
 
   claude-sandboxed = pkgs.writeShellScriptBin "claude" ''
@@ -319,13 +319,13 @@ let
 
   apm-cli = python.buildPythonApplication rec {
     pname = "apm-cli";
-    version = "0.14.2";
+    version = "0.28.0";
     pyproject = true;
 
     src = python.fetchPypi {
       pname = "apm_cli";
       inherit version;
-      hash = "sha256-VuuhiLhsfOe8eqkzJ4YNLRFvZUAygYZ/HmU2Vhhif+E=";
+      hash = "sha256-82JToQeMU3B82MIagQb3x/LRV5x7cYWE22G9o1P3RSE=";
     };
 
     build-system = [ python.setuptools ];
@@ -344,6 +344,8 @@ let
       rich-click
       ruamel-yaml
       toml
+      tomlkit
+      truststore
       watchdog
       websockets
     ];


### PR DESCRIPTION
## 概要

apm-cli と codex-cli を最新版へ更新する。

| 対象 | 変更 |
| --- | --- |
| apm-cli | 0.14.2 → 0.28.0 |
| codex-cli | 0.147.0 → 0.149.1（`codex-cli-nix` を `edc9233` → `05b1b39`） |

## 変更内容

- `apm-cli` の version と sdist hash を更新し、0.28.0 の新規必須依存である `tomlkit` と `truststore` を `dependencies` に追加した。
- `apm/apm.yml` の `target: claude,agent-skills` を、apm が canonical form とする `targets:` のリスト形式へ揃えた。単数 `target:` の CSV 表記も 0.28.0 で有効なため、機能上の差はない。
- codex sandbox wrapper の参照先を `bin/codex-raw` から `libexec/codex` へ変更した。`codex-cli-nix` の更新で上流が実バイナリの位置を移したため。Nix の文字列補間は path の存在を検証しないので、この追随がないと `nix run .#build` は成功して実行時にだけ失敗する。

`flake.lock` は `nix flake update codex-cli-nix` による限定更新で、トップレベルの `nixpkgs` は据え置き。差分に現れるもう 1 つの `nixpkgs` ノードは `codex-cli-nix` の子 input。

## 検証

- `nix run .#build` 成功。
- `nix run .#switch` 適用後、`codex --version` が `codex-cli 0.149.1`、`apm --version` が 0.28.0。
- `apm install -g` 成功（36 依存）。

## 注意

apm 0.28.0 は deploy したファイルを `apm.lock.yaml` の `deployments:` に全列挙する。`node_modules` を含む skill があると lockfile が読み込み時の安全上限を超え、以降の `apm install -g` が失敗する。`explain-diff` を正本 repository で実行して `node_modules` が再生成された場合は再発するため、正本側で `node_modules` を skill ディレクトリ外へ出す対応が別途必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)