### PR TITLE
feat(nono): Azure CLIをagent sandboxから使えるようにする

### DIFF
--- a/nix/modules/darwin/system.nix
+++ b/nix/modules/darwin/system.nix
@@ -70,6 +70,7 @@
     ];
 
     brews = [
+      "azure-cli"
       "container"
       "docker"
       "docker-compose"

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -72,6 +72,7 @@ in
     $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/wrangler" "${homeDirectory}/.local/state/nono-agent-tools/pub-cache"
     ${lib.optionalString pkgs.stdenv.isDarwin ''
       $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/tmp"
+      $DRY_RUN_CMD mkdir -p "${homeDirectory}/.azure"
     ''}
     $DRY_RUN_CMD mkdir -p "${homeDirectory}/.dart-tool" "${homeDirectory}/.dartServer" "${configHome}/flutter"
     for legacy_profile in chouge-agent-common chouge-codex chouge-claude chouge-pi; do

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -18,6 +18,8 @@
       "WRANGLER_LOG_PATH": "$HOME/.local/state/nono-agent-tools/wrangler/logs",
       "WRANGLER_REGISTRY_PATH": "$HOME/.local/state/nono-agent-tools/wrangler/registry",
       "MINIFLARE_REGISTRY_PATH": "$HOME/.local/state/nono-agent-tools/wrangler/registry",
+      // az CLIはcommandごとにtelemetryをuploadするが、送信先は許可対象ではないため既定で無効にする。
+      "AZURE_CORE_COLLECT_TELEMETRY": "0",
     },
   },
   "unsafe_macos_seatbelt_rules": [
@@ -105,6 +107,13 @@
       "*.ts.net",
       // hatena
       "*.hatena.sh",
+      // Azure CLIの認証とtoken更新、ARM control plane、Log Analytics/Application Insightsのquery data plane。
+      // ARMはresource削除を含む書き込みも同じhostで行うため、リソース操作を委譲する判断としてhost単位で許可する。
+      // query data planeを使うlog-analytics/application-insights extensionの導入はsandbox外で行う。
+      "login.microsoftonline.com",
+      "management.azure.com",
+      "api.loganalytics.io",
+      "api.applicationinsights.io",
     ],
   },
   "filesystem": {
@@ -173,7 +182,12 @@
         },
       },
       "filesystem": {
-        "allow": ["$HOME/.local/state/nono-agent-tools/tmp"],
+        // az CLIはaccount showのような読み取り系コマンドでもtoken cacheとlogを更新するため、
+        // read-onlyでは機能しない。az loginによる新規発行はsandbox外で行う運用は維持する。
+        // bypass_protectionは同じsubtree内のfilesystem.denyを無効化するため、config directory配下は
+        // token cacheを含めて読み書きできる。azure-cliを導入するmacOSだけに解除範囲を閉じる。
+        "allow": ["$HOME/.local/state/nono-agent-tools/tmp", "$HOME/.azure"],
+        "bypass_protection": ["$HOME/.azure"],
         "read": ["$HOME/.vite-plus"],
         "write_file": [
           "$HOME/.vite-plus/cache/resolve_cache.json",

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -142,6 +142,21 @@ assert_path_read_is_denied() {
   fi
 }
 
+assert_path_is_exempt_from_credential_deny() {
+  local path="$1"
+  local output
+
+  # Arrange: grant rootはactivationが作るため、grantの有無ではなくgroup由来のdenyだけを見る。
+  # Act: nonoにcredential pathの判定理由を問い合わせる。
+  output="$(nono why --profile "$profile" --path "$path" --op readwrite)"
+
+  # Assert: bypass_protectionがdeny_credentialsを解除している。
+  if [[ "$output" == *"Reason: sensitive_path"* ]]; then
+    printf 'expected %s to be exempt from deny_credentials, got:\n%s\n' "$path" "$output" >&2
+    return 1
+  fi
+}
+
 assert_path_decision() {
   local expected="$1"
   local target_path="$2"
@@ -490,8 +505,84 @@ test_common_profile_allows_tailscale_serve_origins() {
   assert_host_decision "ALLOWED" "machine.tailnet.ts.net"
 }
 
-test_common_profile_denies_unconfigured_clouds() {
-  assert_host_decision "DENIED" management.azure.com
+test_common_profile_does_not_add_aws_control_plane_endpoints() {
+  # Arrange & Act: 共通profileが宣言していないAWSのcontrol plane hostを評価する。
+  # Assert: enterprise profileがLLM API向けに許可するsuffix以外へは広がっていない。
+  assert_host_decision "DENIED" sts.amazonaws.com
+  assert_host_decision "DENIED" ec2.amazonaws.com
+}
+
+test_common_profile_allows_only_the_azure_cli_control_and_query_endpoints() {
+  # Arrange & Act: Azure CLIの認証、ARM、log query先と、その隣接hostを評価する。
+  # Assert: azure-cliの正常系に必要なexact hostだけを共通profileから利用できる。
+  assert_host_decision "ALLOWED" login.microsoftonline.com
+  assert_host_decision "ALLOWED" management.azure.com
+  assert_host_decision "ALLOWED" api.loganalytics.io
+  assert_host_decision "ALLOWED" api.applicationinsights.io
+  assert_host_decision "DENIED" attacker.login.microsoftonline.com
+  assert_host_decision "DENIED" attacker.management.azure.com
+  assert_host_decision "DENIED" attacker.api.loganalytics.io
+  assert_host_decision "DENIED" unrelated.azure.com
+  # Assert: directoryのAPIはリソース操作とlog調査に不要なため許可しない。
+  assert_host_decision "DENIED" graph.microsoft.com
+}
+
+test_agent_profiles_inherit_azure_cli_endpoints() {
+  local agent
+
+  # Arrange: azure-cliは共通profile経由で全agentから使う。
+  for agent in codex claude pi; do
+    # Act & Assert: profile合成後もexact hostだけが許可される。
+    assert_agent_host_decision "$agent" "ALLOWED" "login.microsoftonline.com" 443
+    assert_agent_host_decision "$agent" "ALLOWED" "management.azure.com" 443
+    assert_agent_host_decision "$agent" "ALLOWED" "api.loganalytics.io" 443
+
+    # Act & Assert: 隣接domainへは grant が広がらない。
+    assert_agent_host_decision "$agent" "DENIED" "attacker.management.azure.com" 443
+    assert_agent_host_decision "$agent" "DENIED" "unrelated.azure.com" 443
+  done
+}
+
+test_common_profile_allows_azure_cli_state_without_broadening_credential_access() {
+  local agent
+
+  # Arrange: azure-cliはread-onlyのsubcommandでもtoken cacheをconfig directoryへ書くため、
+  # deny_credentialsの解除が要る。解除範囲はazure-cliを導入するmacOSだけに閉じる。
+  # Act & Assert: 解除もgrantも、cross-platformセクションには置かない。
+  assert_profile_value '.filesystem.allow | index("$HOME/.azure") == null' 'true'
+  assert_profile_value '.filesystem.bypass_protection | index("$HOME/.azure") == null' 'true'
+  assert_profile_array_contains '.platform_overrides.macos.filesystem.allow' '$HOME/.azure'
+  assert_profile_array_contains '.platform_overrides.macos.filesystem.bypass_protection' '$HOME/.azure'
+  assert_profile_value \
+    '(.platform_overrides.linux.filesystem.allow // []) | index("$HOME/.azure") == null' \
+    'true'
+  assert_profile_value \
+    '(.platform_overrides.linux.filesystem.bypass_protection // []) | index("$HOME/.azure") == null' \
+    'true'
+
+  # Assert: az CLIのtelemetryは許可対象外のendpointへ送るため、既定で無効にする。
+  assert_profile_value '.environment.set_vars.AZURE_CORE_COLLECT_TELEMETRY' '0'
+
+  # Assert: 他のcloudのcredentialはprotectionを解除しない。
+  for agent in codex claude pi; do
+    assert_agent_path_decision "$agent" "DENIED" "$HOME/.aws/credentials" "read"
+  done
+
+  # Assert: macOSでは合成後のprofileでcredential denyが実際に外れている。
+  if [[ "$OSTYPE" == darwin* ]]; then
+    assert_path_is_exempt_from_credential_deny "$HOME/.azure/msal_token_cache.json"
+  fi
+}
+
+test_azure_cli_installation_matches_its_sandbox_grants() {
+  # Arrange: profileはazure-cliがhostに導入済みで、grant rootが作成済みであることを前提にする。
+  # Act & Assert: grant rootの作成は、profileが解除を行うmacOSと同じ条件の内側に置く。
+  sed -n "/isDarwin ''/,/^    ''}/p" nix/modules/home/dotfiles.nix \
+    | rg -q -F '$DRY_RUN_CMD mkdir -p "${homeDirectory}/.azure"'
+
+  # Assert: onActivation.cleanupでuninstallされないよう、brewsの内側に宣言する。
+  rg -U -q -- 'brews = \[\n(\s+("[^"]+"|#.*)\n)*\s+"azure-cli"' \
+    nix/modules/darwin/system.nix
 }
 
 test_common_profile_allows_all_ghq_repositories() {
@@ -822,7 +913,11 @@ test_common_profile_allows_github_actions_blob_log_endpoint
 test_common_profile_does_not_allow_azure_blob_apex
 test_common_profile_does_not_allow_adjacent_azure_storage_suffix
 test_common_profile_allows_tailscale_serve_origins
-test_common_profile_denies_unconfigured_clouds
+test_common_profile_does_not_add_aws_control_plane_endpoints
+test_common_profile_allows_only_the_azure_cli_control_and_query_endpoints
+test_agent_profiles_inherit_azure_cli_endpoints
+test_common_profile_allows_azure_cli_state_without_broadening_credential_access
+test_azure_cli_installation_matches_its_sandbox_grants
 test_common_profile_allows_all_ghq_repositories
 test_common_profile_allows_new_ghq_clone_destinations
 test_common_profile_configures_sandbox_compatible_javascript_tools


### PR DESCRIPTION
## 概要

agent sandbox から Azure CLI を使えるようにする。
nono profile の grant 追加だけでは `az` 本体が入らないため、Homebrew での導入と grant root の作成も同じ変更に含める。

## 変更内容

### nono profile

- `$HOME/.azure` の `bypass_protection` を解除し、read/write を許可する。
  `az` は `account show` のような読み取り系 command でも token cache と log を config directory へ書くため、read-only の grant では起動しない。
  `bypass_protection` は同じ subtree 内の deny を無効化するため、解除範囲は azure-cli を導入する macOS だけに閉じている。`az login` による新規発行を sandbox 外で行う運用は変えない。
- network は exact host だけを許可する。
  - `login.microsoftonline.com` — AAD の token 取得
  - `management.azure.com` — ARM control plane
  - `api.loganalytics.io` / `api.applicationinsights.io` — log query の data plane
  - ARM はリソース削除も同じ host で行うため、リソース操作の委譲を許容する判断として host 単位で開けている。
  - `graph.microsoft.com` はリソース操作と log 調査に不要なため許可しない。
- `AZURE_CORE_COLLECT_TELEMETRY=0` を設定する。telemetry の送信先は許可対象に含めていないため。

### Nix

- `nix/modules/darwin/system.nix` の `brews` に `azure-cli` を追加する。`onActivation.cleanup = "uninstall"` があるため、ここに宣言しないと switch のたびにアンインストールされる。
- `nix/modules/home/dotfiles.nix` で `$HOME/.azure` を作成する。profile が解除を行う macOS と同じ条件の内側に置いている。

### テスト

`tests/nono-profile.sh` に 5 test を追加する。

- 許可した exact host と、その隣接 domain (`attacker.management.azure.com`、`unrelated.azure.com` など) の拒否
- 全 agent profile (codex / claude / pi) が合成後も同じ判定になること
- `$HOME/.azure` の解除が cross-platform セクションではなく macOS override 側にあること、Linux 側へ漏れていないこと
- 他 cloud の credential (`$HOME/.aws/credentials`) の protection が解除されていないこと
- `brews` への宣言と grant root の作成が宣言どおり存在すること

置き換えた `test_common_profile_denies_unconfigured_clouds` の AWS 側の意図は `test_common_profile_does_not_add_aws_control_plane_endpoints` として残している。

## 検証

- `tests/nono-profile.sh` — 全通過
- `nix run .#build` — 成功
- macOS へ `nix run .#switch` 適用後、sandbox 内で `az` 2.89.1 が起動することを確認
- 適用後の sandbox で実コマンドを実行し、nono 由来の denial が出ないことを確認
  - `az account show`
  - `az cognitiveservices account list`
  - `az cognitiveservices account deployment list`
  - `az monitor diagnostic-settings list`
  - `az monitor metrics list`
- 適用後の profile 判定で `graph.microsoft.com` が DENIED のままであることを確認

## 範囲

azure-cli の導入は Homebrew 経由のため macOS のみ。WSL 側は対象外で、profile の解除も macOS override に閉じている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
