### PR TITLE
chore(apm): 廃止した explain-diff と teach をグローバル skill から外す

### DIFF
--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -20,7 +20,6 @@ dependencies:
     - path: ~/ghq/github.com/nananaman/skills/meta/apm-usage
     - path: ~/ghq/github.com/nananaman/skills/meta/update-skills
     - path: ~/ghq/github.com/nananaman/skills/engineering/review-diff-code
-    - path: ~/ghq/github.com/nananaman/skills/engineering/explain-diff
     - path: ~/ghq/github.com/nananaman/skills/engineering/implement
     - path: ~/ghq/github.com/nananaman/skills/engineering/simplify-code
     - path: ~/ghq/github.com/nananaman/skills/engineering/tdd
@@ -36,7 +35,6 @@ dependencies:
     - path: ~/ghq/github.com/nananaman/skills/writing/japanese-tech-writing
     - path: ~/ghq/github.com/nananaman/skills/productivity/grilling
     - path: ~/ghq/github.com/nananaman/skills/productivity/grill-me
-    - path: ~/ghq/github.com/nananaman/skills/productivity/teach
     - path: ~/ghq/github.com/nananaman/skills/productivity/handoff
     - path: ~/ghq/github.com/nananaman/skills/productivity/herdr
     - path: ~/ghq/github.com/nananaman/skills/productivity/host-artifact

--- a/tests/host-artifact-service.sh
+++ b/tests/host-artifact-service.sh
@@ -288,9 +288,8 @@ test_server_profile_cannot_follow_a_publish_symlink_outside_the_root() {
 test_apm_installs_the_host_artifact_skill() {
   # Arrange: The LaunchAgent wrapper references the globally installed skill path.
   # Act: Inspect the source-of-truth APM dependency list.
-  # Assert: host-artifact is installed without removing explain-diff.
+  # Assert: host-artifact is installed.
   rg -q 'path: ~/ghq/github\.com/nananaman/skills/productivity/host-artifact$' "$apm_manifest"
-  rg -q 'path: ~/ghq/github\.com/nananaman/skills/engineering/explain-diff$' "$apm_manifest"
 }
 
 test_launch_agent_uses_the_shared_service_contract


### PR DESCRIPTION
## 概要

- `nananaman/skills` で廃止した `explain-diff` と `teach` を、グローバル skill の一覧から外す。
- 上流: nananaman/skills#90（マージ済み）

## 変更内容

- `apm/apm.yml` から 2 skill の path 参照を削除した。参照先ディレクトリは既に存在しないため、放置すると `apm install -g` が実体のない path を読むことになる。
- `tests/host-artifact-service.sh` の `test_apm_installs_the_host_artifact_skill` から、`explain-diff` が manifest に残っていることの確認を削除した。対象 skill がなくなったため、この assertion は必ず失敗する。host-artifact 自体の確認は残している。

## テスト

- `tests/host-artifact-service.sh` 全体は LaunchAgent の activation やサービス再起動を伴うため未実行。
- 変更した `test_apm_installs_the_host_artifact_skill` の assertion を個別に実行し、host-artifact の行が引き続き一致すること、`explain-diff` の行が manifest に存在しないことを確認した。
- `apm/apm.yml` に残る全 `path:` について、参照先に `SKILL.md` が実在することを確認した（欠損なし）。

## 残作業

- [ ] merge 後に本体 dotfiles の `main` を同期し、`apm install -g` を実行してグローバル install 済みの `~/.claude/skills/explain-diff`、`~/.claude/skills/teach` を整理する。
