### PR TITLE
agent-browser を Nix 管理で導入する

### DIFF
--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -69,7 +69,7 @@ in
     ''}
 
     $DRY_RUN_CMD mkdir -p "${configHome}/nono/profiles"
-    $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/wrangler" "${homeDirectory}/.local/state/nono-agent-tools/pub-cache"
+    $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/wrangler" "${homeDirectory}/.local/state/nono-agent-tools/pub-cache" "${homeDirectory}/.local/state/nono-agent-tools/agent-browser/sockets"
     ${lib.optionalString pkgs.stdenv.isDarwin ''
       $DRY_RUN_CMD mkdir -p "${homeDirectory}/.local/state/nono-agent-tools/tmp"
       $DRY_RUN_CMD mkdir -p "${homeDirectory}/.azure"

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -113,6 +113,57 @@ let
       };
     };
 
+  agent-browser-package =
+    let
+      version = "0.35.2";
+      artifacts = {
+        aarch64-darwin = "agent-browser-darwin-arm64";
+        x86_64-linux = "agent-browser-linux-musl-x64";
+      };
+      artifact = artifacts.${pkgs.stdenv.hostPlatform.system};
+    in
+    pkgs.stdenvNoCC.mkDerivation {
+      pname = "agent-browser";
+      inherit version;
+
+      src = pkgs.fetchurl {
+        url = "https://registry.npmjs.org/agent-browser/-/agent-browser-${version}.tgz";
+        hash = "sha256-2FtnQn51E7GzD7+Na34Ksto3ssEmYhNOTgfxLm2SjvU=";
+      };
+
+      sourceRoot = "package";
+
+      installPhase = ''
+        runHook preInstall
+
+        install -Dm755 "bin/${artifact}" "$out/bin/agent-browser"
+        mkdir -p "$out/share/agent-browser"
+        cp -R skills skill-data "$out/share/agent-browser/"
+
+        runHook postInstall
+      '';
+
+      meta = {
+        description = "Browser automation CLI for AI agents";
+        homepage = "https://github.com/vercel-labs/agent-browser";
+        license = pkgs.lib.licenses.asl20;
+        mainProgram = "agent-browser";
+        platforms = builtins.attrNames artifacts;
+      };
+    };
+  agent-browser = pkgs.writeShellApplication {
+    name = "agent-browser";
+    runtimeInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.chromium ];
+    text = ''
+      export AGENT_BROWSER_SKILLS_DIR=${agent-browser-package}/share/agent-browser/skill-data
+      ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+        export CFFIXED_USER_HOME="$HOME/.local/state/nono-agent-tools/agent-browser"
+        export AGENT_BROWSER_ARGS="''${AGENT_BROWSER_ARGS:+$AGENT_BROWSER_ARGS,}--no-sandbox"
+      ''}
+      exec ${agent-browser-package}/bin/agent-browser "$@"
+    '';
+  };
+
   canonicalize-herdr-socket = ''
     if [ -n "''${HERDR_SOCKET_PATH:-}" ]; then
       herdr_socket_dir="''${HERDR_SOCKET_PATH%/*}"
@@ -399,6 +450,7 @@ in
     rtk
     sandbox-runtime
     nono-cli
+    agent-browser
     agent-wrappers
     tirith
 

--- a/nono/profiles/chouge-agent-common.jsonc
+++ b/nono/profiles/chouge-agent-common.jsonc
@@ -18,6 +18,8 @@
       "WRANGLER_LOG_PATH": "$HOME/.local/state/nono-agent-tools/wrangler/logs",
       "WRANGLER_REGISTRY_PATH": "$HOME/.local/state/nono-agent-tools/wrangler/registry",
       "MINIFLARE_REGISTRY_PATH": "$HOME/.local/state/nono-agent-tools/wrangler/registry",
+      // agent-browserのdaemon socketをcredentialを含み得るuser configから分離する。
+      "AGENT_BROWSER_SOCKET_DIR": "$HOME/.local/state/nono-agent-tools/agent-browser/sockets",
       // az CLIはcommandごとにtelemetryをuploadするが、送信先は許可対象ではないため既定で無効にする。
       "AZURE_CORE_COLLECT_TELEMETRY": "0",
     },
@@ -38,6 +40,33 @@
     // agent専用TMPDIRの内側だけでbindと接続を許可する。
     "(allow network-bind (subpath \"@HOME@/.local/state/nono-agent-tools/tmp\"))",
     "(allow network-outbound (subpath \"@HOME@/.local/state/nono-agent-tools/tmp\"))",
+    //////////////////////////
+    // agent-browser
+    //////////////////////////
+    // agent-browserのCLIとdaemonはsessionごとに生成されるUnix socketで通信する。
+    "(allow network-bind (regex \"^@HOME@/.local/state/nono-agent-tools/agent-browser/sockets/[^/]+$\"))",
+    "(allow network-outbound (regex \"^@HOME@/.local/state/nono-agent-tools/agent-browser/sockets/[^/]+$\"))",
+    // Chrome DevToolsはOS割当のlocalhost portをbindする。
+    // macOS Seatbeltはbind/inboundをportで絞れないため、outbound proxyは維持してlocalhost IPCに必要な2操作を許可する。
+    "(allow network-bind)",
+    "(allow network-inbound)",
+    // agent-browserがChromeのOS割当CDP portへ接続するlocalhost通信だけを許可する。
+    "(allow network-outbound (remote tcp \"localhost:*\"))",
+    // Chromeは起動時にmacOSの既定値を読み取る。writeは専用CFFIXED_USER_HOMEへ隔離したまま許可しない。
+    "(allow user-preference-read)",
+    // Chromeが自身のapp bundleをhelper processへread extensionとして渡す操作だけを許可する。
+    "(allow file-issue-extension (require-all (extension-class \"com.apple.app-sandbox.read\") (subpath \"/Applications/Google Chrome.app\")))",
+    // Chromeのheadless起動時に電源状態を参照するuser clientだけを許可する。
+    "(allow iokit-open (iokit-user-client-class \"RootDomainUserClient\"))",
+    // ChromeのProcessSingletonはmacOSの一時領域にランダム名のdirectoryとsocketを作る。
+    // Chrome自身のdirectory prefixだけにfilesystemとUnix socketの権限を限定する。
+    "(allow file-read* file-write* (regex \"^(/private)?/var/folders/[^/]+/[^/]+/T/com\\.google\\.Chrome\\.[^/]+(/.*)?$\"))",
+    "(allow network-bind (regex \"^(/private)?/var/folders/[^/]+/[^/]+/T/com\\.google\\.Chrome\\.[^/]+(/.*)?$\"))",
+    "(allow network-outbound (regex \"^(/private)?/var/folders/[^/]+/[^/]+/T/com\\.google\\.Chrome\\.[^/]+(/.*)?$\"))",
+    // ChromeのCrashpadが起動時に登録する一時handshake serviceだけを許可する。
+    "(allow mach-register (global-name-regex #\"^org\\.chromium\\.crashpad\\.child_port_handshake\\.\"))",
+    // Chromeがbrowser processとhelper processのMach port交換に登録するPID付きserviceだけを許可する。
+    "(allow mach-register (global-name-regex #\"^com\\.google\\.Chrome\\.MachPortRendezvousServer\\.[0-9]+$\"))",
     // host-artifactは親sandboxから固定serviceとTailscale daemonだけを利用する。
     "(allow network-outbound (remote tcp \"localhost:9417\"))",
     "(allow mach-lookup (global-name \"io.tailscale.ipn.macsys-spks\"))",
@@ -144,6 +173,7 @@
       "$HOME/.config/gcloud",
       "$HOME/.local/state/nono-agent-tools/wrangler",
       "$HOME/.local/state/nono-agent-tools/pub-cache",
+      "$HOME/.local/state/nono-agent-tools/agent-browser",
     ],
     "allow_file": [
       "$HOME/.claude.json",

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -402,8 +402,78 @@ test_common_profile_uses_a_dedicated_agent_tmpdir_for_unix_sockets() {
     '[.unsafe_macos_seatbelt_rules[] | select(contains("nono-agent-tools/tmp"))] | tojson' \
     '["(allow network-bind (subpath \"@HOME@/.local/state/nono-agent-tools/tmp\"))","(allow network-outbound (subpath \"@HOME@/.local/state/nono-agent-tools/tmp\"))"]'
   assert_profile_value \
-    '[.unsafe_macos_seatbelt_rules[] | select(contains("/private/var/folders"))] | length' \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("(subpath \"/private/var/folders"))] | length' \
     '0'
+}
+
+test_common_profile_isolates_agent_browser_runtime_state() {
+  # Arrange: agent-browserのdaemonはCLI間通信にruntime socketを作成する。
+  # Act & Assert: 専用stateだけを共有し、親state directoryや通常のbrowser dataへ権限を広げない。
+  assert_profile_value \
+    '.environment.set_vars.AGENT_BROWSER_SOCKET_DIR' \
+    '$HOME/.local/state/nono-agent-tools/agent-browser/sockets'
+  assert_profile_array_contains \
+    '.filesystem.allow' \
+    '$HOME/.local/state/nono-agent-tools/agent-browser'
+  assert_profile_value \
+    '.filesystem.allow | index("$HOME/.local/state/nono-agent-tools") == null' \
+    'true'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("nono-agent-tools/agent-browser/sockets"))] | tojson' \
+    '["(allow network-bind (regex \"^@HOME@/.local/state/nono-agent-tools/agent-browser/sockets/[^/]+$\"))","(allow network-outbound (regex \"^@HOME@/.local/state/nono-agent-tools/agent-browser/sockets/[^/]+$\"))"]'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(. == "(allow network-bind)")] | length' \
+    '1'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(. == "(allow network-inbound)")] | length' \
+    '1'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(. == "(allow network-outbound (remote tcp \"localhost:*\"))")] | length' \
+    '1'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(. == "(allow user-preference-read)")] | length' \
+    '1'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("file-issue-extension") and contains("com.apple.app-sandbox.read") and contains("/Applications/Google Chrome.app"))] | length' \
+    '1'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(. == "(allow iokit-open (iokit-user-client-class \"RootDomainUserClient\"))")] | length' \
+    '1'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("com\\.google\\.Chrome\\.MachPortRendezvousServer"))] | length' \
+    '1'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("com\\.google\\.Chrome") and contains("/var/folders/"))] | length' \
+    '3'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("^(/private)?/var/folders/"))] | length' \
+    '3'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("com\\.google\\.Chrome") and contains("(regex #"))] | length' \
+    '0'
+  assert_profile_value \
+    '[.unsafe_macos_seatbelt_rules[] | select(contains("org\\.chromium\\.crashpad\\.child_port_handshake"))] | tojson' \
+    '["(allow mach-register (global-name-regex #\"^org\\.chromium\\.crashpad\\.child_port_handshake\\.\"))"]'
+}
+
+test_agent_browser_wrapper_isolates_chrome_application_state() {
+  local packages_module='nix/modules/home/packages.nix'
+
+  # Arrange: macOS Chrome derives Crashpad storage from the Core Foundation home.
+  # Act & Assert: Only the agent-browser wrapper redirects it into the granted agent state.
+  rg -q -F 'CFFIXED_USER_HOME="$HOME/.local/state/nono-agent-tools/agent-browser"' \
+    "$packages_module"
+  rg -q -F 'export AGENT_BROWSER_ARGS=' \
+    "$packages_module"
+  rg -q -F -- '--no-sandbox' \
+    "$packages_module"
+  ! rg -q -F -- '--disable-gpu' "$packages_module"
+  rg -q -F 'exec ${agent-browser-package}/bin/agent-browser "$@"' \
+    "$packages_module"
+  rg -q -F 'cp -R skills skill-data "$out/share/agent-browser/"' \
+    "$packages_module"
+  rg -q -F 'AGENT_BROWSER_SKILLS_DIR=${agent-browser-package}/share/agent-browser/skill-data' \
+    "$packages_module"
 }
 
 test_common_profile_uses_enterprise_network() {
@@ -916,6 +986,8 @@ test_common_profile_keeps_chrome_data_outside_direct_agent_access
 test_common_profile_allows_only_the_chrome_bridge_socket_subtree
 test_common_profile_allows_only_the_nix_daemon_socket
 test_common_profile_uses_a_dedicated_agent_tmpdir_for_unix_sockets
+test_common_profile_isolates_agent_browser_runtime_state
+test_agent_browser_wrapper_isolates_chrome_application_state
 test_common_profile_uses_enterprise_network
 test_common_profile_allows_development_endpoints
 test_agent_profiles_inherit_langfuse_cloud_endpoints


### PR DESCRIPTION
## 概要

- `agent-browser` 0.35.2 を Nix 管理で macOS（aarch64-darwin）と WSL（x86_64-linux）へ導入する
- nono sandbox 内で `agent-browser` が Chrome を起動し、ページを操作できるようにする
- agent-browser の runtime state と socket を専用ディレクトリへ隔離する

## 変更内容

- npm 配布物から platform 固有 binary と bundled skills を配置する package / wrapper を追加
- Linux では Chromium を runtime dependency として追加
- macOS では Chrome の state を専用 `CFFIXED_USER_HOME` に分離し、外側の nono sandbox と併用するため `--no-sandbox` を付与
- Chrome DevTools、ProcessSingleton、Crashpad、Mach port rendezvous に必要な最小範囲の nono Seatbelt rule を追加
- profile と wrapper の回帰テストを追加

## 動作確認

- `bash tests/nono-profile.sh`
- `nono profile validate ~/.config/nono/profiles/chouge-agent-common.jsonc`
- `nix run .#build`
- macOS で `nix run .#switch`
- switch 後の新規 Codex sandbox session で次を確認
  - `agent-browser skills list` が bundled skills を表示する
  - OpenAI Developers を open / title 取得 / snapshot / close できる

WSL 向け構成は Nix 評価と配布 artifact を確認済みです。手元に x86_64-linux builder がないため、WSL 上での runtime smoke test は未実施です。

## 注意点

macOS Seatbelt では Chrome が動的に割り当てる CDP port を port 単位で制限できないため、`network-bind` と `network-inbound` は macOS profile 内で広く許可しています。外向き通信は既存の nono network profile を維持し、CDP 接続は localhost に限定しています。
