### PR TITLE
nono wrapperを生成物の振る舞いでテストする

### DIFF
--- a/nix/modules/home/agent-wrappers.nix
+++ b/nix/modules/home/agent-wrappers.nix
@@ -1,0 +1,41 @@
+{ pkgs }:
+{
+  codex =
+    {
+      canonicalizeHerdrSocket,
+      nono,
+      codexGuard,
+      codex,
+    }:
+    pkgs.writeShellScriptBin "codex" (
+      builtins.replaceStrings
+        [ "@CANONICALIZE_HERDR_SOCKET@" "@NONO@" "@CODEX_GUARD@" "@CODEX@" ]
+        [
+          canonicalizeHerdrSocket
+          nono
+          codexGuard
+          codex
+        ]
+        (builtins.readFile ./codex-wrapper.sh)
+    );
+
+  claude =
+    { canonicalizeHerdrSocket, nono }:
+    pkgs.writeShellScriptBin "claude" (
+      builtins.replaceStrings [ "@CANONICALIZE_HERDR_SOCKET@" "@NONO@" ] [ canonicalizeHerdrSocket nono ]
+        (builtins.readFile ./claude-wrapper.sh)
+    );
+
+  pi =
+    { canonicalizeHerdrSocket, nono }:
+    pkgs.writeShellScriptBin "pi" (
+      builtins.replaceStrings [ "@CANONICALIZE_HERDR_SOCKET@" "@NONO@" ] [ canonicalizeHerdrSocket nono ]
+        (builtins.readFile ./pi-wrapper.sh)
+    );
+
+  container =
+    { container }:
+    pkgs.writeShellScriptBin "container" (
+      builtins.replaceStrings [ "@CONTAINER@" ] [ container ] (builtins.readFile ./container-wrapper.sh)
+    );
+}

--- a/nix/modules/home/claude-wrapper.sh
+++ b/nix/modules/home/claude-wrapper.sh
@@ -1,0 +1,24 @@
+@CANONICALIZE_HERDR_SOCKET@
+claude_bin="$HOME/.local/bin/claude"
+if [ ! -x "$claude_bin" ]; then
+  echo "claude: raw executable not found: $claude_bin" >&2
+  exit 127
+fi
+if [ -n "${NONO_CAP_FILE:-}" ]; then
+  exec "$claude_bin" "$@"
+fi
+if [ "$#" -eq 1 ]; then
+  case "$1" in
+    update | upgrade)
+      # Native self-update replaces $HOME/.local/bin/claude via a rename, which needs
+      # write access to the whole containing directory. Run it outside the sandbox
+      # rather than granting that directory-wide write to every sandboxed session.
+      # Guarded to exactly one argv so an unquoted prompt beginning with "update"
+      # (claude's positional prompt argument) cannot also take this path.
+      exec "$claude_bin" "$@"
+      ;;
+  esac
+fi
+HERDR_AGENT=claude exec @NONO@ run --silent \
+  --profile "$HOME/.config/nono/profiles/chouge-claude.jsonc" --allow-cwd --allow-launch-services -- \
+  "$claude_bin" --dangerously-skip-permissions "$@"

--- a/nix/modules/home/codex-wrapper.sh
+++ b/nix/modules/home/codex-wrapper.sh
@@ -1,0 +1,10 @@
+@CANONICALIZE_HERDR_SOCKET@
+export CODEX_EXECUTABLE_PATH="$HOME/.local/share/nono-agent-wrappers/codex"
+export DISABLE_AUTOUPDATER=1
+if [ -n "${NONO_CAP_FILE:-}" ]; then
+  exec @CODEX@ --sandbox danger-full-access --ask-for-approval never "$@"
+fi
+HERDR_AGENT=codex exec @NONO@ run --silent \
+  --profile "$HOME/.config/nono/profiles/chouge-codex.jsonc" --allow-cwd -- \
+  @CODEX_GUARD@ \
+  @CODEX@ --sandbox danger-full-access --ask-for-approval never "$@"

--- a/nix/modules/home/container-wrapper.sh
+++ b/nix/modules/home/container-wrapper.sh
@@ -1,0 +1,8 @@
+# Codex sessionではagent wrapper directoryがnonoのTool Sandbox shimよりPATHの前に置かれる。
+# Homebrew launcherを直接実行するとlibexec/containerが親sandboxに拒否されるため、
+# nonoが生成したshimへ明示的に委譲する。
+if [ -n "${NONO_TOOL_SANDBOX_SHIM_DIR:-}" ] &&
+  [ -x "$NONO_TOOL_SANDBOX_SHIM_DIR/container" ]; then
+  exec "$NONO_TOOL_SANDBOX_SHIM_DIR/container" "$@"
+fi
+exec @CONTAINER@ "$@"

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -7,6 +7,7 @@
 let
   python = pkgs.python313Packages;
   agent-wrapper-dir = ".local/share/nono-agent-wrappers";
+  agent-wrapper = import ./agent-wrappers.nix { inherit pkgs; };
 
   azure-ai-inference = python.buildPythonPackage rec {
     pname = "azure-ai-inference";
@@ -182,70 +183,24 @@ let
     exec "$@"
   '';
 
-  codex-sandboxed = pkgs.writeShellScriptBin "codex" ''
-    ${canonicalize-herdr-socket}
-    export CODEX_EXECUTABLE_PATH="$HOME/${agent-wrapper-dir}/codex"
-    export DISABLE_AUTOUPDATER=1
-    if [ -n "''${NONO_CAP_FILE:-}" ]; then
-      exec ${codexCliPackage}/libexec/codex --sandbox danger-full-access --ask-for-approval never "$@"
-    fi
-    HERDR_AGENT=codex exec ${nono-cli}/bin/nono run --silent \
-      --profile "$HOME/.config/nono/profiles/chouge-codex.jsonc" --allow-cwd -- \
-      ${codex-nono-guard} \
-      ${codexCliPackage}/libexec/codex --sandbox danger-full-access --ask-for-approval never "$@"
-  '';
+  codex-sandboxed = agent-wrapper.codex {
+    canonicalizeHerdrSocket = canonicalize-herdr-socket;
+    nono = "${nono-cli}/bin/nono";
+    codexGuard = "${codex-nono-guard}";
+    codex = "${codexCliPackage}/libexec/codex";
+  };
 
-  claude-sandboxed = pkgs.writeShellScriptBin "claude" ''
-    ${canonicalize-herdr-socket}
-    claude_bin="$HOME/.local/bin/claude"
-    if [ ! -x "$claude_bin" ]; then
-      echo "claude: raw executable not found: $claude_bin" >&2
-      exit 127
-    fi
-    if [ -n "''${NONO_CAP_FILE:-}" ]; then
-      exec "$claude_bin" "$@"
-    fi
-    if [ "$#" -eq 1 ]; then
-      case "$1" in
-        update | upgrade)
-          # Native self-update replaces $HOME/.local/bin/claude via a rename, which needs
-          # write access to the whole containing directory. Run it outside the sandbox
-          # rather than granting that directory-wide write to every sandboxed session.
-          # Guarded to exactly one argv so an unquoted prompt beginning with "update"
-          # (claude's positional prompt argument) cannot also take this path.
-          exec "$claude_bin" "$@"
-          ;;
-      esac
-    fi
-    HERDR_AGENT=claude exec ${nono-cli}/bin/nono run --silent \
-      --profile "$HOME/.config/nono/profiles/chouge-claude.jsonc" --allow-cwd --allow-launch-services -- \
-      "$claude_bin" --dangerously-skip-permissions "$@"
-  '';
+  claude-sandboxed = agent-wrapper.claude {
+    canonicalizeHerdrSocket = canonicalize-herdr-socket;
+    nono = "${nono-cli}/bin/nono";
+  };
 
-  pi-sandboxed = pkgs.writeShellScriptBin "pi" ''
-    ${canonicalize-herdr-socket}
-    pi_bin="$HOME/.vite-plus/bin/pi"
-    if [ ! -x "$pi_bin" ]; then
-      echo "pi: raw executable not found: $pi_bin" >&2
-      exit 127
-    fi
-    if [ -n "''${NONO_CAP_FILE:-}" ]; then
-      exec "$pi_bin" "$@"
-    fi
-    HERDR_AGENT=pi exec ${nono-cli}/bin/nono run --silent \
-      --profile "$HOME/.config/nono/profiles/chouge-pi.jsonc" --allow-cwd -- "$pi_bin" "$@"
-  '';
+  pi-sandboxed = agent-wrapper.pi {
+    canonicalizeHerdrSocket = canonicalize-herdr-socket;
+    nono = "${nono-cli}/bin/nono";
+  };
 
-  container-sandboxed = pkgs.writeShellScriptBin "container" ''
-    # Codex sessionではagent wrapper directoryがnonoのTool Sandbox shimよりPATHの前に置かれる。
-    # Homebrew launcherを直接実行するとlibexec/containerが親sandboxに拒否されるため、
-    # nonoが生成したshimへ明示的に委譲する。
-    if [ -n "''${NONO_TOOL_SANDBOX_SHIM_DIR:-}" ] &&
-      [ -x "$NONO_TOOL_SANDBOX_SHIM_DIR/container" ]; then
-      exec "$NONO_TOOL_SANDBOX_SHIM_DIR/container" "$@"
-    fi
-    exec /opt/homebrew/bin/container "$@"
-  '';
+  container-sandboxed = agent-wrapper.container { container = "/opt/homebrew/bin/container"; };
 
   host-artifact-service = pkgs.writeShellScriptBin "host-artifact-service" ''
     if [ "$#" -ne 1 ] || [ "$1" != "ensure" ]; then

--- a/nix/modules/home/pi-wrapper.sh
+++ b/nix/modules/home/pi-wrapper.sh
@@ -1,0 +1,11 @@
+@CANONICALIZE_HERDR_SOCKET@
+pi_bin="$HOME/.vite-plus/bin/pi"
+if [ ! -x "$pi_bin" ]; then
+  echo "pi: raw executable not found: $pi_bin" >&2
+  exit 127
+fi
+if [ -n "${NONO_CAP_FILE:-}" ]; then
+  exec "$pi_bin" "$@"
+fi
+HERDR_AGENT=pi exec @NONO@ run --silent \
+  --profile "$HOME/.config/nono/profiles/chouge-pi.jsonc" --allow-cwd -- "$pi_bin" "$@"

--- a/tests/agent-wrapper-behavior.sh
+++ b/tests/agent-wrapper-behavior.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/agent-wrapper-test.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+
+call_log="$test_root/calls.log"
+fake_nono="$test_root/fake-nono"
+fake_claude="$test_root/home/.local/bin/claude"
+fake_codex="$test_root/fake-codex"
+fake_codex_guard="$test_root/fake-codex-guard"
+fake_container="$test_root/fake-container"
+fake_pi="$test_root/home/.vite-plus/bin/pi"
+rendered_claude="$test_root/claude"
+rendered_codex="$test_root/codex"
+rendered_container="$test_root/container"
+rendered_pi="$test_root/pi"
+
+mkdir -p "$(dirname "$fake_claude")" "$(dirname "$fake_pi")"
+
+write_call_recorder() {
+  local output="$1"
+  local name="$2"
+
+  sed \
+    -e "s|@NAME@|$name|g" \
+    -e "s|@CALL_LOG@|$call_log|g" \
+    tests/fixtures/fake-agent-command.sh >"$output"
+  chmod +x "$output"
+}
+
+build_wrappers() {
+  local repository_root
+  local wrapper_outputs
+
+  repository_root="$(pwd -P)"
+  wrapper_outputs="$(
+    REPOSITORY_ROOT="$repository_root" \
+      FAKE_NONO="$fake_nono" \
+      FAKE_CODEX="$fake_codex" \
+      FAKE_CODEX_GUARD="$fake_codex_guard" \
+      FAKE_CONTAINER="$fake_container" \
+      nix build --impure --no-link --print-out-paths --expr '
+        let
+          repositoryRoot = builtins.getEnv "REPOSITORY_ROOT";
+          flake = builtins.getFlake repositoryRoot;
+          pkgs = import flake.inputs.nixpkgs {
+            system = builtins.currentSystem;
+          };
+          wrapper = import (repositoryRoot + "/nix/modules/home/agent-wrappers.nix") { inherit pkgs; };
+        in
+        [
+          (wrapper.claude {
+            canonicalizeHerdrSocket = "";
+            nono = builtins.getEnv "FAKE_NONO";
+          })
+          (wrapper.codex {
+            canonicalizeHerdrSocket = "";
+            nono = builtins.getEnv "FAKE_NONO";
+            codexGuard = builtins.getEnv "FAKE_CODEX_GUARD";
+            codex = builtins.getEnv "FAKE_CODEX";
+          })
+          (wrapper.container {
+            container = builtins.getEnv "FAKE_CONTAINER";
+          })
+          (wrapper.pi {
+            canonicalizeHerdrSocket = "";
+            nono = builtins.getEnv "FAKE_NONO";
+          })
+        ]
+      '
+  )"
+
+  while IFS= read -r wrapper_output; do
+    if [[ -x "$wrapper_output/bin/claude" ]]; then
+      rendered_claude="$wrapper_output/bin/claude"
+    elif [[ -x "$wrapper_output/bin/codex" ]]; then
+      rendered_codex="$wrapper_output/bin/codex"
+    elif [[ -x "$wrapper_output/bin/container" ]]; then
+      rendered_container="$wrapper_output/bin/container"
+    elif [[ -x "$wrapper_output/bin/pi" ]]; then
+      rendered_pi="$wrapper_output/bin/pi"
+    fi
+  done <<<"$wrapper_outputs"
+}
+
+assert_calls_equal() {
+  local expected="$1"
+  local actual
+
+  actual="$(cat "$call_log")"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'expected calls:\n%s\nactual calls:\n%s\n' "$expected" "$actual" >&2
+    return 1
+  fi
+}
+
+test_claude_update_runs_outside_the_sandbox() {
+  # Arrange: self-update先とnonoを、argvを記録するfakeへ置き換える。
+  : >"$call_log"
+  write_call_recorder "$fake_nono" nono
+  write_call_recorder "$fake_claude" claude
+
+  # Act: directory全体の置換権限が必要なself-updateを起動する。
+  env -u NONO_CAP_FILE HOME="$test_root/home" CALL_LOG="$call_log" "$rendered_claude" update
+
+  # Assert: self-updateだけはnonoを介さずraw executableへ委譲する。
+  assert_calls_equal 'claude
+update'
+}
+
+test_claude_prompt_runs_inside_the_sandbox() {
+  # Arrange: 通常のpromptとnonoの呼び出しを観測できるようにする。
+  : >"$call_log"
+  write_call_recorder "$fake_nono" nono
+  write_call_recorder "$fake_claude" claude
+
+  # Act: 通常のpromptをwrapperへ渡す。
+  env -u NONO_CAP_FILE HOME="$test_root/home" CALL_LOG="$call_log" \
+    "$rendered_claude" 'review the README'
+
+  # Assert: promptとraw executableはnono runのargvとして保持される。
+  assert_calls_equal "nono
+run
+--silent
+--profile
+$test_root/home/.config/nono/profiles/chouge-claude.jsonc
+--allow-cwd
+--allow-launch-services
+--
+$fake_claude
+--dangerously-skip-permissions
+review the README"
+}
+
+test_claude_update_prefix_with_more_arguments_stays_sandboxed() {
+  # Arrange: self-updateに似た通常promptをnonoのfakeで観測する。
+  : >"$call_log"
+  write_call_recorder "$fake_nono" nono
+  write_call_recorder "$fake_claude" claude
+
+  # Act: updateから始まる複数引数をwrapperへ渡す。
+  env -u NONO_CAP_FILE HOME="$test_root/home" CALL_LOG="$call_log" \
+    "$rendered_claude" update README
+
+  # Assert: 完全なself-update呼び出しでないためnono境界を迂回しない。
+  assert_calls_equal "nono
+run
+--silent
+--profile
+$test_root/home/.config/nono/profiles/chouge-claude.jsonc
+--allow-cwd
+--allow-launch-services
+--
+$fake_claude
+--dangerously-skip-permissions
+update
+README"
+}
+
+test_codex_parent_session_runs_inside_the_sandbox() {
+  # Arrange: nono、guard、Codex実体をargv記録用fakeへ置き換える。
+  : >"$call_log"
+  write_call_recorder "$fake_nono" nono
+  write_call_recorder "$fake_codex" codex
+  write_call_recorder "$fake_codex_guard" codex-guard
+
+  # Act: nono capabilityが未注入の親sessionからCodexを起動する。
+  env -u NONO_CAP_FILE HOME="$test_root/home" CALL_LOG="$call_log" \
+    "$rendered_codex" exec 'argument with spaces'
+
+  # Assert: guardとraw実体を含む完全なargvがnono runへ渡される。
+  assert_calls_equal "nono
+run
+--silent
+--profile
+$test_root/home/.config/nono/profiles/chouge-codex.jsonc
+--allow-cwd
+--
+$fake_codex_guard
+$fake_codex
+--sandbox
+danger-full-access
+--ask-for-approval
+never
+exec
+argument with spaces"
+}
+
+test_codex_child_session_uses_the_raw_executable() {
+  # Arrange: 既にnono内にいるsessionでCodex実体への委譲だけを観測する。
+  : >"$call_log"
+  write_call_recorder "$fake_nono" nono
+  write_call_recorder "$fake_codex" codex
+  write_call_recorder "$fake_codex_guard" codex-guard
+
+  # Act: capabilityを注入済みとしてnested Codexを起動する。
+  NONO_CAP_FILE="$test_root/cap.json" HOME="$test_root/home" CALL_LOG="$call_log" \
+    "$rendered_codex" resume
+
+  # Assert: 二重sandboxを作らずraw Codexへ固定security引数を渡す。
+  assert_calls_equal "codex
+--sandbox
+danger-full-access
+--ask-for-approval
+never
+resume"
+}
+
+test_container_prefers_the_tool_sandbox_shim() {
+  local shim_dir="$test_root/shims"
+
+  # Arrange: Tool Sandbox shimとhost側containerの両方を観測可能にする。
+  : >"$call_log"
+  mkdir -p "$shim_dir"
+  write_call_recorder "$shim_dir/container" container-shim
+  write_call_recorder "$fake_container" container-host
+
+  # Act: shimが注入されたsessionからcontainerを起動する。
+  NONO_TOOL_SANDBOX_SHIM_DIR="$shim_dir" CALL_LOG="$call_log" \
+    "$rendered_container" image list
+
+  # Assert: host launcherではなくshimへargvを保持して委譲する。
+  assert_calls_equal 'container-shim
+image
+list'
+}
+
+test_container_falls_back_to_the_host_executable_without_a_shim() {
+  # Arrange: shimがない通常環境でhost側containerだけを観測可能にする。
+  : >"$call_log"
+  write_call_recorder "$fake_container" container-host
+
+  # Act: Tool Sandbox shimなしでcontainerを起動する。
+  env -u NONO_TOOL_SANDBOX_SHIM_DIR CALL_LOG="$call_log" \
+    "$rendered_container" system status
+
+  # Assert: host実体へargvを保持してfallbackする。
+  assert_calls_equal 'container-host
+system
+status'
+}
+
+test_pi_parent_session_runs_inside_the_sandbox() {
+  # Arrange: Pi実体とnonoをargv記録用fakeへ置き換える。
+  : >"$call_log"
+  write_call_recorder "$fake_nono" nono
+  write_call_recorder "$fake_pi" pi
+
+  # Act: nono capabilityが未注入の親sessionからPiを起動する。
+  env -u NONO_CAP_FILE HOME="$test_root/home" CALL_LOG="$call_log" \
+    "$rendered_pi" --mode plan
+
+  # Assert: raw Pi実体と利用者のargvがnono runへ渡される。
+  assert_calls_equal "nono
+run
+--silent
+--profile
+$test_root/home/.config/nono/profiles/chouge-pi.jsonc
+--allow-cwd
+--
+$fake_pi
+--mode
+plan"
+}
+
+test_pi_child_session_uses_the_raw_executable() {
+  # Arrange: 既にnono内にいるsessionでPi実体への委譲だけを観測する。
+  : >"$call_log"
+  write_call_recorder "$fake_nono" nono
+  write_call_recorder "$fake_pi" pi
+
+  # Act: capabilityを注入済みとしてnested Piを起動する。
+  NONO_CAP_FILE="$test_root/cap.json" HOME="$test_root/home" CALL_LOG="$call_log" \
+    "$rendered_pi" resume
+
+  # Assert: 二重sandboxを作らずraw Piへargvを保持して委譲する。
+  assert_calls_equal 'pi
+resume'
+}
+
+write_call_recorder "$fake_nono" nono
+write_call_recorder "$fake_claude" claude
+write_call_recorder "$fake_codex" codex
+write_call_recorder "$fake_codex_guard" codex-guard
+write_call_recorder "$fake_container" container-host
+write_call_recorder "$fake_pi" pi
+build_wrappers
+
+test_claude_update_runs_outside_the_sandbox
+test_claude_prompt_runs_inside_the_sandbox
+test_claude_update_prefix_with_more_arguments_stays_sandboxed
+test_codex_parent_session_runs_inside_the_sandbox
+test_codex_child_session_uses_the_raw_executable
+test_container_prefers_the_tool_sandbox_shim
+test_container_falls_back_to_the_host_executable_without_a_shim
+test_pi_parent_session_runs_inside_the_sandbox
+test_pi_child_session_uses_the_raw_executable

--- a/tests/fixtures/fake-agent-command.sh
+++ b/tests/fixtures/fake-agent-command.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+{
+  printf '%s\n' '@NAME@'
+  printf '%s\n' "$@"
+} >>'@CALL_LOG@'

--- a/tests/nono-profile.sh
+++ b/tests/nono-profile.sh
@@ -778,16 +778,6 @@ test_command_policies_never_require_human_approval() {
     'deny'
 }
 
-test_container_wrapper_prefers_the_tool_sandbox_shim() {
-  local packages_module='nix/modules/home/packages.nix'
-
-  # Arrange: Codex sessionではagent wrapper directoryがnonoのshimよりPATHの前に置かれる。
-  # Act: PATH順序を補正するcontainer wrapperのdispatch条件をsourceから確認する。
-  # Assert: Homebrew launcherからlibexecを直接起動せず、生成済みshimへ委譲する。
-  rg -q 'NONO_TOOL_SANDBOX_SHIM_DIR.*/container' "$packages_module"
-  rg -q 'container-sandboxed' "$packages_module"
-}
-
 test_container_policy_allows_mysql_integration_test_lifecycle() {
   # Arrange, Act & Assert: Repeated test setup and inspection operations are delegated.
   assert_container_command_decision "ALLOWED" image pull mysql:8.0.33
@@ -803,26 +793,6 @@ test_container_policy_keeps_destructive_cleanup_denied() {
   assert_container_command_decision "DENIED" delete katohome-mysql
   assert_container_command_decision "DENIED" prune
   assert_container_command_decision "DENIED" image prune --all
-}
-
-test_codex_wrapper_requires_the_parent_nono_capability() {
-  local packages_module='nix/modules/home/packages.nix'
-
-  # Arrange: Codex自身のsandboxは無効化し、外側のnonoだけをsecurity boundaryとして使う。
-  # Act: nonoが起動するchild commandにcapability確認用guardがあるか調べる。
-  # Assert: NONO_CAP_FILEが注入されなければ、raw Codexを起動する前に失敗する。
-  rg -q 'codex-nono-guard' "$packages_module"
-  rg -q 'codex: nono capability was not injected' "$packages_module"
-}
-
-test_codex_wrapper_uses_the_packaged_entrypoint() {
-  local packages_module='nix/modules/home/packages.nix'
-
-  # Arrange: Codexのpackageは実バイナリをlibexec/codexとして提供する。
-  # Act: sandbox wrapperが起動するpackage内commandをsourceから確認する。
-  # Assert: 廃止されたcodex-rawではなく、packageの実バイナリへ委譲する。
-  rg -q -F '${codexCliPackage}/libexec/codex --sandbox' "$packages_module"
-  ! rg -q -F '${codexCliPackage}/bin/codex-raw' "$packages_module"
 }
 
 test_local_agent_tools_use_the_parent_sandbox() {
@@ -938,7 +908,6 @@ test_claude_allows_login_endpoints_and_launch_services() {
     '["claude.com","bridge.claudeusercontent.com"]'
   assert_agent_profile_value claude '.network.open_port | tojson' '[0]'
   assert_agent_profile_value claude '.allow_launch_services' 'null'
-  rg -q -- '--allow-launch-services' nix/modules/home/packages.nix
 }
 
 test_claude_allows_only_the_chrome_extension_bridge_host() {
@@ -948,28 +917,6 @@ test_claude_allows_only_the_chrome_extension_bridge_host() {
   assert_agent_host_decision claude ALLOWED bridge.claudeusercontent.com 443
   assert_agent_host_decision claude DENIED bridge-staging.claudeusercontent.com 443
   assert_agent_host_decision claude DENIED claudeusercontent.com 443
-}
-
-test_claude_wrapper_runs_self_update_outside_the_sandbox() {
-  local packages_module='nix/modules/home/packages.nix'
-
-  # Arrange: `claude update`のsymlink置き換えは$HOME/.local/bin全体へのwriteを要求し、
-  # 通常sessionのfilesystem境界では表現できない。
-  # Act & Assert: update/upgradeはnono runへ渡す前にraw binaryを直接execする分岐を持つ。
-  rg -q 'update \| upgrade\)' "$packages_module"
-  rg -q -F 'Run it outside the sandbox' "$packages_module"
-}
-
-test_claude_wrapper_self_update_bypass_requires_exactly_one_argument() {
-  local packages_module='nix/modules/home/packages.nix'
-
-  # Arrange: claudeの`prompt`は位置引数のため、`claude update the readme`のような
-  # 未クォートの自然文プロンプトも$1="update"になり得る。
-  # Act & Assert: `update | upgrade)`のcase分岐が、単独の文字列一致ではなく
-  # 引数個数1個のif guardの内側に入れ子になっていることを確認する。
-  rg -U -q -- \
-    'if \[ "\$#" -eq 1 \]; then\n\s*case "\$1" in\n\s*update \| upgrade\)' \
-    "$packages_module"
 }
 
 test_pi_allows_configured_openai_codex_endpoint() {
@@ -1009,11 +956,8 @@ test_common_profile_allows_new_ghq_clone_destinations
 test_common_profile_configures_sandbox_compatible_javascript_tools
 test_common_profile_allows_flutter_and_dart_runtime_state_without_home_wide_access
 test_command_policies_never_require_human_approval
-test_container_wrapper_prefers_the_tool_sandbox_shim
 test_container_policy_allows_mysql_integration_test_lifecycle
 test_container_policy_keeps_destructive_cleanup_denied
-test_codex_wrapper_requires_the_parent_nono_capability
-test_codex_wrapper_uses_the_packaged_entrypoint
 test_local_agent_tools_use_the_parent_sandbox
 test_host_artifact_publish_root_is_writable_without_broadening_its_parent
 test_host_artifact_uses_the_parent_sandbox_without_tool_policies
@@ -1027,6 +971,4 @@ test_codex_observability_does_not_allow_adjacent_hosts
 test_claude_allows_anthropic_api_endpoint
 test_claude_allows_login_endpoints_and_launch_services
 test_claude_allows_only_the_chrome_extension_bridge_host
-test_claude_wrapper_runs_self_update_outside_the_sandbox
-test_claude_wrapper_self_update_bypass_requires_exactly_one_argument
 test_pi_allows_configured_openai_codex_endpoint


### PR DESCRIPTION
## 概要

- nono agent wrapperのテストを、Nix sourceへの文字列検索から生成wrapperの実行検証へ置き換える
- productionとテストで同じwrapper生成処理を共有し、argvとsandbox境界を外部から確認できるようにする

## 変更内容

- Codex、Claude、Pi、containerのwrapper生成を`agent-wrappers.nix`へ分離
- fakeのnono・agent実体を注入して、親/子sessionの分岐、Claude self-update境界、container shim fallbackを検証
- 引数の空白や複数引数が保持されることを検証
- 同じ契約をsource文字列で確認していたgrepテストを削除

## テスト

- `bash tests/agent-wrapper-behavior.sh`
- `bash tests/nono-profile.sh`
- `bash tests/nvim-agent-sandbox.sh`
- `git diff --check`
- `nix run .#build`
