### PR TITLE
feat(colima): colima を dotfiles 管理に加える

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ zsh/                       # Zsh configuration
 ghostty/                   # Ghostty terminal configuration
 herdr/                     # Herdr terminal multiplexer configuration
 aerospace/                 # AeroSpace window manager
+colima/                    # Colima VM config template for new profiles
 lazygit/                   # Lazygit configuration
 git/                       # Git config & ignore
 apm/                       # Global agent skills managed by APM

--- a/colima/default.yaml
+++ b/colima/default.yaml
@@ -1,0 +1,297 @@
+# colima が新規プロファイルを作成するときに読む設定テンプレート。
+# 既存プロファイルには適用されないため、値を変えたら `colima delete` して作り直す。
+# 値の変更はこのファイルを直接編集する。`colima template` は symlink 越しに
+# このファイルを書き換え、このヘッダーを落とす。
+#
+# colima v0.10.3 の embedded/defaults/colima.yaml をそのまま取り込み、memory だけ変更している。
+# colima はテンプレートに書かれた key を無条件で採用し、欠けた key は既定値ではなく
+# ゼロ値になる。colima を upgrade したら upstream の embedded/defaults/colima.yaml と
+# diff を取り直し、追加された key を取り込むこと。
+
+# Number of CPUs to be allocated to the virtual machine.
+# Default: 2
+cpu: 2
+
+# Size of the disk in GiB to be allocated to the virtual machine for container data.
+# NOTE: value can only be increased after virtual machine has been created.
+#
+# Default: 100
+disk: 100
+
+# Size of the memory in GiB to be allocated to the virtual machine.
+# Default: 2
+memory: 8
+
+# Architecture of the virtual machine (x86_64, aarch64, host).
+#
+# NOTE: value cannot be changed after virtual machine is created.
+# Default: host
+arch: host
+
+# Container runtime to be used (docker, containerd).
+#
+# NOTE: value cannot be changed after virtual machine is created.
+# Default: docker
+runtime: docker
+
+# AI model runner (docker, ramalama).
+# Both require krunkit VM type for GPU access.
+# docker: Uses Docker Model Runner.
+# ramalama: Uses Ramalama.
+#
+# Default: docker
+modelRunner: docker
+
+# Set custom hostname for the virtual machine.
+# Default: colima
+#          colima-profile_name for other profiles
+hostname: null
+
+# Kubernetes configuration for the virtual machine.
+kubernetes:
+  # Enable kubernetes.
+  # Default: false
+  enabled: false
+
+  # Kubernetes version to use.
+  # This needs to exactly match a k3s version https://github.com/k3s-io/k3s/releases
+  # Default: latest stable release
+  version: v1.35.0+k3s1
+
+  # Additional args to pass to k3s https://docs.k3s.io/cli/server
+  # Default: traefik is disabled
+  k3sArgs: [--disable=traefik]
+
+  # Kubernetes port to listen on
+  # A common port is 6443, though left unbound to ensure no port conflicts
+  # Default: pick random unbound port
+  port: 0
+
+# Auto-activate on the Host for client access.
+# Setting to true does the following on startup
+#  - sets as active Docker context (for Docker runtime).
+#  - sets as active Kubernetes context (if Kubernetes is enabled).
+#  - sets as active Incus remote (for Incus runtime).
+# Default: true
+autoActivate: true
+
+# Network configurations for the virtual machine.
+network:
+  # Assign reachable IP address to the virtual machine.
+  # NOTE: this is currently macOS only and ignored on Linux.
+  # Default: false
+  address: false
+
+  # Network mode for the virtual machine (shared, bridged).
+  # NOTE: this is currently macOS only and ignored on Linux.
+  # Default: shared
+  mode: shared
+
+  # Network interface to use for bridged mode.
+  # This is only used when mode is set to bridged.
+  # NOTE: this is currently macOS only and ignored on Linux.
+  # Default: en0
+  interface: en0
+
+  # Use the assigned IP address as the preferred route for the VM.
+  # Note: this only has an effect when `address` is set to true.
+  # Default: false
+  preferredRoute: false
+
+  # Custom DNS resolvers for the virtual machine.
+  #
+  # EXAMPLE
+  # dns: [8.8.8.8, 1.1.1.1]
+  #
+  # Default: []
+  dns: []
+
+  # DNS hostnames to resolve to custom targets using the internal resolver.
+  # This setting has no effect if a custom DNS resolver list is supplied above.
+  # It does not configure the /etc/hosts files of any machine or container.
+  # The value can be an IP address or another host.
+  #
+  # EXAMPLE
+  # dnsHosts:
+  #   example.com: 1.2.3.4
+  dnsHosts:
+    host.docker.internal: host.lima.internal
+
+  # Replicate host IP addresses in the VM. This enables port forwarding to specific
+  # host IP addresses.
+  #   e.g. `docker run --port 10.0.1.2:8080:8080 alpine` would only forward to the
+  #   specified IP address.
+  #
+  # Default: false
+  hostAddresses: false
+
+  # Custom gateway address for the virtual machine.
+  # The last octet needs to be 2.
+  #
+  # EXAMPLE
+  # gatewayAddress: 192.168.10.2
+  #
+  # Default: 192.168.5.2
+  gatewayAddress: 192.168.5.2
+
+# ===================================================================== #
+# ADVANCED CONFIGURATION
+# ===================================================================== #
+
+# Forward the host's SSH agent to the virtual machine.
+# Default: false
+forwardAgent: false
+
+# Docker daemon configuration that maps directly to daemon.json.
+# https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file.
+# NOTE: some settings may affect Colima's ability to start docker. e.g. `hosts`.
+#
+# EXAMPLE - disable buildkit
+# docker:
+#   features:
+#     buildkit: false
+#
+# EXAMPLE - add insecure registries
+# docker:
+#   insecure-registries:
+#     - myregistry.com:5000
+#     - host.docker.internal:5000
+#
+# Colima default behaviour: buildkit enabled
+# Default: {}
+docker: {}
+
+# Virtual Machine type (krunkit, qemu, vz)
+# NOTE: this is macOS 13 only. For Linux and macOS <13.0, qemu is always used.
+#
+# vz is macOS virtualization framework and requires macOS 13.
+# krunkit runs super‑light VMs on macOS/ARM64 with a focus on GPU access. It is experimental.
+#
+# NOTE: value cannot be changed after virtual machine is created.
+# Default: qemu
+vmType: qemu
+
+# Port forwarder for the virtual machine (ssh, grpc, none).
+# ssh is more stable but supports only TCP.
+# grpc supports both TCP and UDP, but is experimental.
+# none disables port forwarding.
+#
+# Default: ssh
+portForwarder: ssh
+
+# Utilise rosetta for amd64 emulation (requires m1 mac and vmType `vz`)
+# Default: false
+rosetta: false
+
+# Enable foreign architecture emulation via binfmt (e.g. amd64 on arm64, arm64 on amd64)
+# Default: true
+binfmt: true
+
+# Enable nested virtualization for the virtual machine (requires m3 mac and vmType `vz`)
+# Default: false
+nestedVirtualization: false
+
+# Volume mount driver for the virtual machine (virtiofs, 9p, sshfs).
+#
+# virtiofs is limited to macOS and vmType `vz`. It is the fastest of the options.
+#
+# 9p is the recommended and the most stable option for vmType `qemu`.
+#
+# sshfs is faster than 9p but the least reliable of the options (when there are lots
+# of concurrent reads or writes).
+#
+# NOTE: value cannot be changed after virtual machine is created.
+# Default: virtiofs (for vz), sshfs (for qemu)
+mountType: sshfs
+
+# Propagate inotify file events to the VM.
+# NOTE: this is experimental.
+mountInotify: false
+
+# The CPU type for the virtual machine (requires vmType `qemu`).
+# Options available for host emulation can be checked with: `qemu-system-$(arch) -cpu help`.
+# Instructions are also supported by appending to the cpu type e.g. "qemu64,+ssse3".
+# Default: host
+cpuType: host
+
+# Custom provision scripts for the virtual machine.
+# Provisioning scripts are executed on startup and therefore needs to be idempotent.
+#
+# EXAMPLE - script executed as root
+# provision:
+#   - mode: system
+#     script: apt-get install htop vim
+#
+# EXAMPLE - script executed as user
+# provision:
+#   - mode: user
+#     script: |
+#       [ -f ~/.provision ] && exit 0;
+#       echo provisioning as $USER...
+#       touch ~/.provision
+#
+# EXAMPLE - script executed after VM boot, before container runtimes start
+# provision:
+#   - mode: after-boot
+#     script: echo "VM is up, containers not yet started"
+#
+# EXAMPLE - script executed after VM and container runtimes are ready
+# provision:
+#   - mode: ready
+#     script: echo "everything is ready"
+#
+# Default: []
+provision: []
+
+# Modify ~/.ssh/config automatically to include a SSH config for the virtual machine.
+# SSH config will still be generated in $COLIMA_HOME/ssh_config regardless.
+# Default: true
+sshConfig: true
+
+# The port number for the SSH server for the virtual machine.
+# When set to 0, a random available port is used.
+#
+# Default: 0
+sshPort: 0
+
+# Configure volume mounts for the virtual machine.
+# Colima mounts user's home directory by default to provide a familiar
+# user experience.
+#
+# EXAMPLE
+# mounts:
+#   - location: ~/secrets
+#     writable: false
+#   - location: ~/projects
+#     writable: true
+#
+# Colima default behaviour: $HOME is mounted as writable.
+# Default: []
+mounts: []
+
+# Specify a custom disk image for the virtual machine.
+# When not specified, Colima downloads an appropriate disk image from Github at
+# https://github.com/abiosoft/colima-core/releases.
+# The file path to a custom disk image can be specified to override the behaviour.
+#
+# Default: ""
+diskImage: ""
+
+# Use the custom disk image even if it does NOT match a supported release image.
+# WARNING: This bypasses validating the image and is a completely unsupported!
+forceDiskImage: false
+
+# Size of the disk in GiB for the root filesystem of the virtual machine.
+# This value is ignored if no runtime is in use. i.e. `none` runtime.
+# Default: 20
+rootDisk: 20
+
+# Environment variables for the virtual machine.
+#
+# EXAMPLE
+# env:
+#   KEY: value
+#   ANOTHER_KEY: another value
+#
+# Default: {}
+env: {}

--- a/nix/modules/darwin/system.nix
+++ b/nix/modules/darwin/system.nix
@@ -71,6 +71,8 @@
 
     brews = [
       "azure-cli"
+      # docker daemon を提供する Linux VM。設定は colima/default.yaml で管理する
+      "colima"
       "container"
       "docker"
       "docker-compose"

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -66,6 +66,11 @@ in
       # Homebrew の docker-buildx は cli-plugins へ自分で配置する必要がある
       $DRY_RUN_CMD mkdir -p "${homeDirectory}/.docker/cli-plugins"
       link_force "/opt/homebrew/opt/docker-buildx/bin/docker-buildx" "${homeDirectory}/.docker/cli-plugins/docker-buildx"
+
+      # colima のプロファイル本体 (~/.colima/<profile>/colima.yaml) は colima 自身が
+      # 起動のたびに書き換えるため、新規プロファイル作成時に読まれるテンプレートだけを管理する
+      $DRY_RUN_CMD mkdir -p "${homeDirectory}/.colima/_templates"
+      link_force "${dotfilesDir}/colima/default.yaml" "${homeDirectory}/.colima/_templates/default.yaml"
     ''}
 
     $DRY_RUN_CMD mkdir -p "${configHome}/nono/profiles"


### PR DESCRIPTION
merge だけでは colima は入らない。適用と、既存プロファイルの作り直しが必要（末尾のチェックリスト参照）。

## 概要

colima を Homebrew と設定テンプレートの両方で dotfiles 管理下に置く。

Homebrew の `onActivation.cleanup = "uninstall"` があるため、手動で `brew install colima` しても `nix run .#switch` のたびに削除される。docker 一式と同じ Homebrew 経路へ宣言的に追加した。

VM 設定は `~/.colima/_templates/default.yaml` へ out-of-store symlink する。プロファイル本体の `colima.yaml` は colima 自身が起動のたびに書き換えるため、管理対象にできない。

## 設定値

`colima start --vm-type qemu --cpu-type host --cpu 2 --memory 8 --disk 100` 相当。`memory` 以外は colima の既定値と一致するため、upstream との実質差分は 1 行。

## テンプレートを全 key の完全コピーにしている理由

colima の `prepareConfig` はテンプレートの値を無条件で採用し、`setConfigDefaults` が補完するのは `vmType` / `mountType` / `hostname` / `portForwarder` の 4 つだけ。欠けた key は既定値ではなく Go のゼロ値になるため（`sshConfig` が false になる、`dnsHosts` の `host.docker.internal` が消える等）、必要な値だけを書いた最小構成のテンプレートは書けない。

そのため `colima/default.yaml` は colima v0.10.3 の `embedded/defaults/colima.yaml` をバイト単位でそのまま取り込み、`memory: 2` → `8` の 1 行だけを変えている。colima を upgrade したときに upstream と再 diff できるよう、この前提はファイル冒頭のコメントに書いた。

## 検証

- `nix run .#build` 成功
- 生成される Brewfile に `brew "colima", trusted: true` が入ることを確認
- activation script に `mkdir -p ~/.colima/_templates` と symlink が生成されることを確認
- `colima/default.yaml` の YAML パースと全 28 key、値（cpu 2 / memory 8 / disk 100 / qemu / host）を確認
- 既存テストは `tests/host-artifact-service.sh` を除き成功。同テストは本 PR の base（309a70a）でも失敗する既存の不具合で、本変更とは無関係

## merge 後の残作業

- [ ] `nix run .#switch` で適用する
- [ ] 既存の `~/.colima` プロファイルがある場合は `colima delete` してから `colima start` する。テンプレートは新規プロファイル作成時にしか読まれないため、既存プロファイルには `memory: 8` が反映されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
