### PR TITLE
fix(colima): vmType qemu に必要な qemu を導入する

### DIFF
--- a/nix/modules/darwin/system.nix
+++ b/nix/modules/darwin/system.nix
@@ -79,6 +79,9 @@
       # credsStore = osxkeychain を解決する docker-credential-osxkeychain を提供する
       "docker-credential-helper"
       "docker-buildx"
+      # colima/default.yaml の vmType: qemu が必要とする qemu-img を提供する。
+      # Homebrew の lima は qemu に依存しないため個別に入れる
+      "qemu"
     ];
 
     casks = [


### PR DESCRIPTION
merge だけでは解消しない。適用が必要（末尾のチェックリスト参照）。

## 問題

#81 で入れた `colima/default.yaml` は `vmType: qemu` を指定しているが、qemu を導入していなかったため `colima start` が config の検証段階で失敗する。

```
FATA[0000] error in config: cannot use vmType: 'qemu', error: qemu-img not found, run 'brew install qemu' to install
```

Homebrew の `lima` formula は qemu に依存しない（`brew deps --installed lima` が空）。macOS では lima の既定が vz に寄っており qemu は任意扱いのため、`colima` → `lima` の依存を辿っても `qemu-img` は入らない。

## 対処

`brews` に `qemu` を追加する。colima の `util/qemu.go` の `AssertQemuImg()` が案内する対処と同一で、`qemu` formula は `vmType: qemu` が要求する `qemu-img` と、`cpuType: host` の解決に使う `qemu-system-aarch64` を同一 formula で提供する。

`vmType: vz` へ切り替えれば qemu は不要になるが、`cpuType: host` が qemu 専用オプションのため無効になる。今回は既存の設定意図を保つ。

## 検証

- `nix run .#build` 成功
- 生成される Brewfile に `brew "qemu", trusted: true` が入ることを確認

## merge 後の残作業

- [ ] `nix run .#switch` で適用する
- [ ] `colima start` で VM を作成する。既存の `~/.colima` プロファイルが残っている場合は `colima delete` してから実行する（テンプレートは新規プロファイル作成時にしか読まれないため、既存プロファイルには `memory: 8` が反映されない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
